### PR TITLE
CMakeLists.txt: Include GNUInstallDirs, add install() call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(Iconv)
 
+include(GNUInstallDirs)
+
 # shared CLI utilities (used by both juice and juice-img)
 add_library(cli_utils STATIC
     src/cli_utils.cpp
@@ -97,3 +99,5 @@ if(BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests)
 endif()
+
+install(TARGETS juice juice-img)


### PR DESCRIPTION
Allows for `make install` to work.

```
Running phase: installPhase
install flags: -j4 SHELL=/nix/store/kysqfpylfpl8yrmgahj1sk6yrih918gl-bash-5.3p9/bin/bash install
[  4%] Built target cli_utils
[ 31%] Built target juice_img_lib
[ 91%] Built target juice_lib
[ 95%] Built target juice-img
[100%] Built target juice
Install the project...
-- Install configuration: "Release"
-- Installing: /nix/store/a0bp9l76xa85v1wx7dci96qd3d9b8kvn-lime-juice-local/bin/juice
-- Installing: /nix/store/a0bp9l76xa85v1wx7dci96qd3d9b8kvn-lime-juice-local/bin/juice-img
```