### PR TITLE
treewide: Add GPL-3.0-or-later copyright headers to code files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,19 @@
+# lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+# Copyright (C) 2026 Fuzion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 cmake_minimum_required(VERSION 3.16)
 project(juice VERSION 0.2.1 LANGUAGES C CXX)
 

--- a/README.md
+++ b/README.md
@@ -296,3 +296,35 @@ The GPA file may not have an embedded palette. Either provide one with `-p palet
 - [ADV Scripting Reference](doc/scripting-adv.md)
 - [GP4 Image Format](doc/gp4-ada.md)
 - [GPC/GPA Image Format](doc/gpc-gpa.md)
+
+## License
+
+```
+lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+Copyright (C) 2026 Fuzion
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+```
+
+---
+
+Most of this project's files are licensed under the GNU Public License, version 3 or later (SPDX: `GPL-3.0-or-later`). For the full text of this license, see the included [`/LICENSE.md`](LICENSE.md).
+
+Exempt from this license are:
+
+- all files in `/docs/` (not code)
+- the external projects included in `/third_party/`
+  - `iconv` ([win-iconv](https://github.com/win-iconv/win-iconv)): Public Domain
+  - `lecram` ([gifenc](https://github.com/lecram/gifenc) & [gifdec](https://github.com/lecram/gifdec)): Public Domain
+  - `lodepng` ([LodePNG](https://github.com/lvandeve/lodepng)): Zlib

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "ast.h"
 
 bool AstNode::operator==(const AstNode& other) const {

--- a/src/ast.h
+++ b/src/ast.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/auto_detect.cpp
+++ b/src/auto_detect.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "auto_detect.h"
 
 #include <algorithm>

--- a/src/auto_detect.h
+++ b/src/auto_detect.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "config.h"

--- a/src/auto_wrap.cpp
+++ b/src/auto_wrap.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "auto_wrap.h"
 
 #include <functional>

--- a/src/auto_wrap.h
+++ b/src/auto_wrap.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "ast.h"

--- a/src/byte_stream.h
+++ b/src/byte_stream.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/byte_writer.h
+++ b/src/byte_writer.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/charset.cpp
+++ b/src/charset.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "charset.h"
 
 #include <cstring>

--- a/src/charset.h
+++ b/src/charset.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/charset/chinese.cpp
+++ b/src/charset/chinese.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // chinese charset definition

--- a/src/charset/english.cpp
+++ b/src/charset/english.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // english charset definition

--- a/src/charset/europe.cpp
+++ b/src/charset/europe.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // europe charset definition

--- a/src/charset/korean.cpp
+++ b/src/charset/korean.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // korean charset definition

--- a/src/charset/korean_gamebox.cpp
+++ b/src/charset/korean_gamebox.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // korean gamebox charset definition

--- a/src/charset/korean_hannuri.cpp
+++ b/src/charset/korean_hannuri.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // korean hannuri charset definition

--- a/src/charset/korean_kk.cpp
+++ b/src/charset/korean_kk.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // korean kk charset definition

--- a/src/charset/korean_parangsae.cpp
+++ b/src/charset/korean_parangsae.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // korean parangsae charset definition

--- a/src/charset/pc98.cpp
+++ b/src/charset/pc98.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "../charset.h"
 
 // pc-98 charset definition

--- a/src/cli_utils.cpp
+++ b/src/cli_utils.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "cli_utils.h"
 
 #include <algorithm>

--- a/src/cli_utils.h
+++ b/src/cli_utils.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/codec/gp4/gp4.h
+++ b/src/codec/gp4/gp4.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "image/image.h"

--- a/src/codec/gp4/gp4_color_table.h
+++ b/src/codec/gp4/gp4_color_table.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <array>

--- a/src/codec/gp4/gp4_decode.cpp
+++ b/src/codec/gp4/gp4_decode.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "codec/gp4/gp4.h"
 #include "codec/gp4/gp4_color_table.h"
 

--- a/src/codec/gp4/gp4_encode.cpp
+++ b/src/codec/gp4/gp4_encode.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "codec/gp4/gp4.h"
 #include "codec/gp4/gp4_color_table.h"
 

--- a/src/codec/gpa/gpa.h
+++ b/src/codec/gpa/gpa.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "image/image.h"

--- a/src/codec/gpa/gpa_decode.cpp
+++ b/src/codec/gpa/gpa_decode.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "codec/gpa/gpa.h"
 #include "codec/gpc/gpc.h"
 #include "codec/gpc/gpc_internal.h"

--- a/src/codec/gpa/gpa_encode.cpp
+++ b/src/codec/gpa/gpa_encode.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "codec/gpa/gpa.h"
 #include "codec/gpc/gpc.h"
 #include "codec/gpc/gpc_internal.h"

--- a/src/codec/gpc/gpc.h
+++ b/src/codec/gpc/gpc.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "image/image.h"

--- a/src/codec/gpc/gpc_decode.cpp
+++ b/src/codec/gpc/gpc_decode.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "codec/gpc/gpc.h"
 #include "codec/gpc/gpc_internal.h"
 

--- a/src/codec/gpc/gpc_encode.cpp
+++ b/src/codec/gpc/gpc_encode.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "codec/gpc/gpc.h"
 #include "codec/gpc/gpc_internal.h"
 

--- a/src/codec/gpc/gpc_internal.h
+++ b/src/codec/gpc/gpc_internal.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "image/image.h"

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "config.h"
 
 #include <algorithm>

--- a/src/config.h
+++ b/src/config.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/engine/adv/compiler.cpp
+++ b/src/engine/adv/compiler.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "compiler.h"
 #include "../../byte_writer.h"
 #include "../../charset.h"

--- a/src/engine/adv/compiler.h
+++ b/src/engine/adv/compiler.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/adv/loader.cpp
+++ b/src/engine/adv/loader.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "loader.h"
 #include "opener.h"
 #include "parser.h"

--- a/src/engine/adv/loader.h
+++ b/src/engine/adv/loader.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/adv/opener.cpp
+++ b/src/engine/adv/opener.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "opener.h"
 
 #include <fstream>

--- a/src/engine/adv/opener.h
+++ b/src/engine/adv/opener.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/engine/adv/parser.cpp
+++ b/src/engine/adv/parser.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "parser.h"
 
 #include <cstdio>

--- a/src/engine/adv/parser.h
+++ b/src/engine/adv/parser.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai1/compiler.cpp
+++ b/src/engine/ai1/compiler.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "compiler.h"
 #include "tokens.h"
 #include "../../byte_writer.h"

--- a/src/engine/ai1/compiler.h
+++ b/src/engine/ai1/compiler.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai1/loader.cpp
+++ b/src/engine/ai1/loader.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "loader.h"
 #include "opener.h"
 #include "parser.h"

--- a/src/engine/ai1/loader.h
+++ b/src/engine/ai1/loader.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai1/opener.cpp
+++ b/src/engine/ai1/opener.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "opener.h"
 
 #include <fstream>

--- a/src/engine/ai1/opener.h
+++ b/src/engine/ai1/opener.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/engine/ai1/parser.cpp
+++ b/src/engine/ai1/parser.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "parser.h"
 
 namespace ai1 {

--- a/src/engine/ai1/parser.h
+++ b/src/engine/ai1/parser.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai1/tokens.h
+++ b/src/engine/ai1/tokens.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/engine/ai5/compiler.cpp
+++ b/src/engine/ai5/compiler.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "compiler.h"
 #include "tokens.h"
 #include "../ai1/compiler.h"

--- a/src/engine/ai5/compiler.h
+++ b/src/engine/ai5/compiler.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai5/loader.cpp
+++ b/src/engine/ai5/loader.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "loader.h"
 #include "opener.h"
 #include "parser.h"

--- a/src/engine/ai5/loader.h
+++ b/src/engine/ai5/loader.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai5/opener.cpp
+++ b/src/engine/ai5/opener.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "opener.h"
 
 #include <fstream>

--- a/src/engine/ai5/opener.h
+++ b/src/engine/ai5/opener.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../engine.h"

--- a/src/engine/ai5/parser.cpp
+++ b/src/engine/ai5/parser.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "parser.h"
 
 namespace ai5 {

--- a/src/engine/ai5/parser.h
+++ b/src/engine/ai5/parser.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../../ast.h"

--- a/src/engine/ai5/tokens.h
+++ b/src/engine/ai5/tokens.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <cstdint>

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "../ast.h"

--- a/src/engine/parse_error.h
+++ b/src/engine/parse_error.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <stdexcept>

--- a/src/image/gif_io.cpp
+++ b/src/image/gif_io.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "image/gif_io.h"
 
 #include <lecram/gifdec.h>

--- a/src/image/gif_io.h
+++ b/src/image/gif_io.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "image/image.h"

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "image/image.h"
 
 // GP4 palette entry: 16-bit BE, bits GGGG_xRRRR_xBBBB_01

--- a/src/image/image.h
+++ b/src/image/image.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <array>

--- a/src/image/png_io.cpp
+++ b/src/image/png_io.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "image/png_io.h"
 
 #include <lodepng/lodepng.h>

--- a/src/image/png_io.h
+++ b/src/image/png_io.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "image/image.h"

--- a/src/img_main.cpp
+++ b/src/img_main.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "cli_utils.h"
 #include "codec/gp4/gp4.h"
 #include "codec/gpc/gpc.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "auto_detect.h"
 #include "auto_wrap.h"
 #include "cli_utils.h"

--- a/src/sexp_reader.cpp
+++ b/src/sexp_reader.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "sexp_reader.h"
 
 #include <cctype>

--- a/src/sexp_reader.h
+++ b/src/sexp_reader.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "ast.h"

--- a/src/sexp_writer.cpp
+++ b/src/sexp_writer.cpp
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include "sexp_writer.h"
 #include "utf8.h"
 

--- a/src/sexp_writer.h
+++ b/src/sexp_writer.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include "ast.h"

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -1,3 +1,21 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 
 #include <string>

--- a/tests/test_decompile.sh
+++ b/tests/test_decompile.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+# Copyright (C) 2026 Fuzion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 # corpus test: decompile every MES file, report per-game results
 # uses default engine (AI5) unless overridden via ENGINE env var
 

--- a/tests/test_roundtrip.sh
+++ b/tests/test_roundtrip.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+# Copyright (C) 2026 Fuzion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 # semantic round-trip test for the compiler
 # usage: ./test_roundtrip.sh <directory> [--strict]
 # tests all .rkt files (excluding .mes.rkt) in the given directory.

--- a/tools/tokdumpadv.py
+++ b/tools/tokdumpadv.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+#
+# lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+# Copyright (C) 2026 Fuzion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 """barebones ADV MES token dumper. linear scan, no tree structure."""
 
 import sys


### PR DESCRIPTION
And add details in the README about the copyright, and which files are exempt from this license (docs, third-party projects).