### PR TITLE
Added support for missing Spanish punctuation such as double arrow quotations and inverted exclamation mark.

### DIFF
--- a/src/charset/europe.cpp
+++ b/src/charset/europe.cpp
@@ -27,7 +27,7 @@ void register_charset_europe(Charset& cs) {
 
     // additional european punctuation at kuten row 47, starting at column 92
     // (charset* 47 92 #\« #\» #\¡)
-    cs.register_kuten_range_str(47, 92, u8"«»¡");
+    cs.register_kuten_range_str(47, 91, u8"—«»¡");
 
     // ASCII at kuten row 48, starting at column 1
     // (charset* 48 1 #\! #\" ... #\~)

--- a/src/charset/europe.cpp
+++ b/src/charset/europe.cpp
@@ -25,6 +25,10 @@ void register_charset_europe(Charset& cs) {
     // chains pc98 as base
     register_charset_pc98(cs);
 
+    // additional european punctuation at kuten row 47, starting at column 92
+    // (charset* 47 92 #\« #\» #\¡)
+    cs.register_kuten_range_str(47, 92, u8"«»¡");
+
     // ASCII at kuten row 48, starting at column 1
     // (charset* 48 1 #\! #\" ... #\~)
     cs.register_kuten_range(48, 1, {


### PR DESCRIPTION
<img width="1205" height="817" alt="image" src="https://github.com/user-attachments/assets/7d09ea94-3fe7-4a87-a32e-d1af80139b2c" />
<img width="1205" height="817" alt="image" src="https://github.com/user-attachments/assets/a4c9ebe9-276a-45b6-982e-b20b2dc77fac" />
