### PR TITLE
feat: add General Message engine support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(juice_lib STATIC
     src/engine/adv/loader.cpp
     src/engine/adv/compiler.cpp
     src/engine/gm/opener.cpp
+    src/engine/gm/walker.cpp
     src/engine/gm/loader.cpp
     src/engine/gm/compiler.cpp
     src/auto_detect.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ add_library(juice_lib STATIC
     src/engine/adv/parser.cpp
     src/engine/adv/loader.cpp
     src/engine/adv/compiler.cpp
+    src/engine/gm/opener.cpp
+    src/engine/gm/loader.cpp
+    src/engine/gm/compiler.cpp
     src/auto_detect.cpp
     src/auto_wrap.cpp
 )

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ A companion tool, **juice-img**, handles the image formats used by the same game
 
 ## Supported Engines
 
-Six engine versions were used across these games. Functionally, they fall into three distinct families:
+Several engine versions were used across these games. Juice currently supports four distinct families:
 
 | Family | Versions | Notes | Game list |
 |--------|----------|-------|-----------|
 | **AI1** | AI1, AI2 | Older engine with simpler bytecode. AI2 is functionally identical to AI1. | [AI1/AI2 games](https://vndb.org/r?q=&o=a&s=title&f=12fgAIfoAI2) |
 | **AI5** | AI4, AI5 | The most common engine. AI4 is functionally identical to AI5. | [AI4/AI5 games](https://vndb.org/r?q=&o=a&s=title&f=12foAI4foAI5) |
 | **ADV** | AI3, ADV | Advanced engine with segment-based structure. ADV forked from AI3; they are functionally equivalent. | [AI3/ADV games](https://vndb.org/r?f=fwADV98V-) |
+| **GM** | General Message | Partially understood PC-98 engine. Text is editable; unknown bytecode is preserved losslessly as `(raw ...)`. | |
 
 **AI5WIN**, a Windows port of AI5, also exists but is not currently supported by juice. It shares most of its bytecode format with AI5 but has some Windows-specific differences.
 
@@ -65,7 +66,7 @@ Settings from the preset are stored in the RKT file's `(meta ...)` block, so you
 
 | Flag | Description |
 |------|-------------|
-| `-e`, `--engine TYPE` | Engine type: `AI5` (default), `AI1`, `ADV`. Aliases: `AI2` maps to `AI1`, `AI4` maps to `AI5`, `AI5X` maps to `AI5` with `--dictbase D0 --extraop`. |
+| `-e`, `--engine TYPE` | Engine type: `AI5` (default), `AI1`, `ADV`, `GM`. Aliases: `AI2` maps to `AI1`, `AI4` maps to `AI5`, `AI5X` maps to `AI5` with `--dictbase D0 --extraop`. |
 | `-p`, `--preset NAME` | Apply a named game preset. Overrides engine, charset, and other defaults. See `--show-preset` for the full list. |
 
 ### Character Encoding
@@ -186,6 +187,11 @@ When compiling, juice reads settings from the `(meta ...)` block at the top of t
 (meta (engine 'AI5) (charset "pc98") (extraop #t))
 ```
 
+General Message scripts use `(engine 'GM)`. Their self-delimiting text records
+are written as `(gm-text MODE "...")`; bytecode whose instruction layout is not
+yet known is kept in `(raw ...)` nodes. Leave those raw nodes intact to retain a
+byte-exact round trip.
+
 ### Input/Output Handling
 
 - Accepts multiple input files. Glob patterns (`*`, `?`) are expanded automatically.
@@ -294,6 +300,7 @@ The GPA file may not have an embedded palette. Either provide one with `-p palet
 - [AI5 Scripting Reference](doc/scripting-ai5.md)
 - [AI1 Scripting Reference](doc/scripting-ai1.md)
 - [ADV Scripting Reference](doc/scripting-adv.md)
+- [General Message Scripting Notes](doc/scripting-gm.md)
 - [GP4 Image Format](doc/gp4-ada.md)
 - [GPC/GPA Image Format](doc/gpc-gpa.md)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Several engine versions were used across these games. Juice currently supports f
 | **AI1** | AI1, AI2 | Older engine with simpler bytecode. AI2 is functionally identical to AI1. | [AI1/AI2 games](https://vndb.org/r?q=&o=a&s=title&f=12fgAIfoAI2) |
 | **AI5** | AI4, AI5 | The most common engine. AI4 is functionally identical to AI5. | [AI4/AI5 games](https://vndb.org/r?q=&o=a&s=title&f=12foAI4foAI5) |
 | **ADV** | AI3, ADV | Advanced engine with segment-based structure. ADV forked from AI3; they are functionally equivalent. | [AI3/ADV games](https://vndb.org/r?f=fwADV98V-) |
-| **GM** | General Message | Partially understood PC-98 engine. Text is editable with local control-target relocation; unknown bytecode is preserved losslessly as `(raw ...)`. | |
+| **GM** | General Message | Partially understood PC-98 engine. Text is editable with local control-target relocation; unknown bytecode is preserved losslessly as `(raw ...)`. | *Fermion: Mirai kara no Houmonsha* (validated dialect) |
 
 **AI5WIN**, a Windows port of AI5, also exists but is not currently supported by juice. It shares most of its bytecode format with AI5 but has some Windows-specific differences.
 
@@ -151,6 +151,7 @@ Presets bundle the correct engine, dictionary base, extraop, and protagonist set
 | `dk3` | Dragon Knight 3 | AI5 | protag: proc 26 |
 | `dk4` | Dragon Knight 4 | AI5 | defaults |
 | `elle` | ELLE | AI5 | protag: variable Z |
+| `fermion` | Fermion: Mirai kara no Houmonsha | GM | defaults |
 | `foxy` | Foxy | AI5 | defaults |
 | `foxy2` | Foxy 2 | AI5 | defaults |
 | `isaku` | Isaku | AI5 | dictbase D0, extraop |
@@ -187,12 +188,14 @@ When compiling, juice reads settings from the `(meta ...)` block at the top of t
 (meta (engine 'AI5) (charset "pc98") (extraop #t))
 ```
 
-General Message scripts use `(engine 'GM)`. Their self-delimiting text records
-are written as `(gm-text MODE "...")`; bytecode whose instruction layout is not
-yet semantic is kept in `(raw ...)` nodes. A generated `(gm-layout ...)` block
-records source spans and native local address fields, allowing the compiler to
-backpatch control targets when text changes length. Leave the layout and raw
-node lengths intact.
+General Message scripts use `(engine 'GM)`. Current support is derived from and
+validated against *Fermion: Mirai kara no Houmonsha*'s General Message system-1
+Rev.95:06:30 dialect. Their self-delimiting text records are written as
+`(gm-text MODE "...")`; bytecode whose instruction layout is not yet semantic is
+kept in `(raw ...)` nodes. A generated `(gm-layout ...)` block records source
+spans and native local address fields, allowing the compiler to backpatch
+control targets when text changes length. Leave the layout and raw node lengths
+intact.
 
 ### Input/Output Handling
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Several engine versions were used across these games. Juice currently supports f
 | **AI1** | AI1, AI2 | Older engine with simpler bytecode. AI2 is functionally identical to AI1. | [AI1/AI2 games](https://vndb.org/r?q=&o=a&s=title&f=12fgAIfoAI2) |
 | **AI5** | AI4, AI5 | The most common engine. AI4 is functionally identical to AI5. | [AI4/AI5 games](https://vndb.org/r?q=&o=a&s=title&f=12foAI4foAI5) |
 | **ADV** | AI3, ADV | Advanced engine with segment-based structure. ADV forked from AI3; they are functionally equivalent. | [AI3/ADV games](https://vndb.org/r?f=fwADV98V-) |
-| **GM** | General Message | Partially understood PC-98 engine. Text is editable; unknown bytecode is preserved losslessly as `(raw ...)`. | |
+| **GM** | General Message | Partially understood PC-98 engine. Text is editable with local control-target relocation; unknown bytecode is preserved losslessly as `(raw ...)`. | |
 
 **AI5WIN**, a Windows port of AI5, also exists but is not currently supported by juice. It shares most of its bytecode format with AI5 but has some Windows-specific differences.
 
@@ -189,8 +189,10 @@ When compiling, juice reads settings from the `(meta ...)` block at the top of t
 
 General Message scripts use `(engine 'GM)`. Their self-delimiting text records
 are written as `(gm-text MODE "...")`; bytecode whose instruction layout is not
-yet known is kept in `(raw ...)` nodes. Leave those raw nodes intact to retain a
-byte-exact round trip.
+yet semantic is kept in `(raw ...)` nodes. A generated `(gm-layout ...)` block
+records source spans and native local address fields, allowing the compiler to
+backpatch control targets when text changes length. Leave the layout and raw
+node lengths intact.
 
 ### Input/Output Handling
 

--- a/doc/scripting-gm.md
+++ b/doc/scripting-gm.md
@@ -5,14 +5,16 @@ looks like AI5 but an incompatible instruction set. A valid GM file begins
 with a little-endian 16-bit code offset. The bytes between offset 2 and the
 code offset are two-byte Shift-JIS dictionary entries.
 
-The interpreter dispatches opcodes `0x30` through `0x7f`. Most instruction
-layouts are not identified yet, so juice preserves unparsed code byte-for-byte
-in `(raw ...)` nodes. Do not edit those nodes unless you know the instruction
-layout and its address operands.
+The interpreter dispatches opcodes `0x30` through `0x7f`. Juice structurally
+walks the complete instruction stream so it can distinguish instructions from
+their payloads and identify local 16-bit control targets. Only text has a
+semantic AST node today; every other complete instruction is preserved
+byte-for-byte in `(raw ...)` nodes.
 
 ## Text (`0x4a`)
 
-Text records are self-delimiting and can therefore be edited safely:
+Text records are self-delimiting and can be edited safely in files decompiled
+by a relocation-aware version of juice:
 
 ```racket
 (gm-text 1 "Japanese text")
@@ -33,6 +35,32 @@ Mode 1 payload tokens are:
 The two dictionary ranges address up to 168 entries. Mode 2 stores printable
 single-byte ASCII directly.
 
+## Layout and relocation metadata
+
+The decompiler writes a `gm-layout` node before the code nodes:
+
+```racket
+(gm-layout
+ (span 6 26)
+ (span 26 34)
+ (span 34 39)
+ (span 39 40)
+ (reloc 21 39))
+```
+
+There is one source `span` for each following `raw` or `gm-text` node. A
+`reloc` records the absolute file offset of a local 16-bit address field and
+its old target. When text changes length, the compiler maps both positions
+through the spans and backpatches the new target. Targets that do not land on
+an instruction boundary in the same MES file, such as calls into an MLL
+module, are deliberately not rewritten.
+
+Keep `gm-layout` and the order of the code nodes intact. Text nodes may change
+length. Raw nodes may be edited in place but cannot change length, because
+juice does not yet have a semantic representation from which to rebuild them.
+Older or hand-written GM source without `gm-layout` remains compilable, but it
+does not have enough provenance for safe changed-length edits.
+
 ## Scenario loading
 
 Three related commands have been identified:
@@ -50,8 +78,9 @@ strong GM auto-detection marker.
 
 ## Current boundary
 
-Juice only gives semantic structure to `0x4a` text records today. It scans for
-records whose complete payload is structurally valid and leaves every other
-byte untouched. This permits translation and exact recompilation without
-claiming that the surrounding control flow is understood. Future opcode
-parsers can replace individual `(raw ...)` regions incrementally.
+Juice only gives semantic structure to `0x4a` text records today. The remaining
+opcode layouts are decoded only far enough to recover instruction boundaries
+and native local address fields. This permits translation, exact unchanged
+round trips, and changed-length relocation without claiming semantic names for
+the surrounding commands. Future opcode parsers can replace individual
+`(raw ...)` regions incrementally while retaining the same layout metadata.

--- a/doc/scripting-gm.md
+++ b/doc/scripting-gm.md
@@ -1,0 +1,57 @@
+# General Message scripting notes
+
+General Message (GM) is a PC-98 scripting engine with a file container that
+looks like AI5 but an incompatible instruction set. A valid GM file begins
+with a little-endian 16-bit code offset. The bytes between offset 2 and the
+code offset are two-byte Shift-JIS dictionary entries.
+
+The interpreter dispatches opcodes `0x30` through `0x7f`. Most instruction
+layouts are not identified yet, so juice preserves unparsed code byte-for-byte
+in `(raw ...)` nodes. Do not edit those nodes unless you know the instruction
+layout and its address operands.
+
+## Text (`0x4a`)
+
+Text records are self-delimiting and can therefore be edited safely:
+
+```racket
+(gm-text 1 "Japanese text")
+(gm-text 2 "ASCII")
+```
+
+The opcode is followed by a mode byte, the payload, and a zero terminator.
+
+Mode 1 payload tokens are:
+
+| Bytes | Meaning |
+|-------|---------|
+| `04` | newline |
+| `18`-`7f` | dictionary entry `token - 0x18` |
+| `a0`-`df` | dictionary entry `token - 0x38` |
+| otherwise | raw two-byte Shift-JIS character |
+
+The two dictionary ranges address up to 168 entries. Mode 2 stores printable
+single-byte ASCII directly.
+
+## Scenario loading
+
+Three related commands have been identified:
+
+| Opcode | Behavior |
+|--------|----------|
+| `0x6d` | replace the current MES scenario |
+| `0x6e` | load an MLL module |
+| `0x6f` | call a nested MES scenario and then restore the caller |
+
+String parameters use token `0x11`, followed by a zero-terminated filename;
+the parameter list itself ends with another zero. A common entry-script
+signature is therefore `6e 11 "system.mll" 00 00`, which juice also uses as a
+strong GM auto-detection marker.
+
+## Current boundary
+
+Juice only gives semantic structure to `0x4a` text records today. It scans for
+records whose complete payload is structurally valid and leaves every other
+byte untouched. This permits translation and exact recompilation without
+claiming that the surrounding control flow is understood. Future opcode
+parsers can replace individual `(raw ...)` regions incrementally.

--- a/doc/scripting-gm.md
+++ b/doc/scripting-gm.md
@@ -1,9 +1,12 @@
 # General Message scripting notes
 
 General Message (GM) is a PC-98 scripting engine with a file container that
-looks like AI5 but an incompatible instruction set. A valid GM file begins
-with a little-endian 16-bit code offset. The bytes between offset 2 and the
-code offset are two-byte Shift-JIS dictionary entries.
+looks like AI5 but an incompatible instruction set. This implementation is
+derived from and validated against *Fermion: Mirai kara no Houmonsha*'s General
+Message system-1 Rev.95:06:30 dialect; other titles and revisions have not yet
+been validated. A valid GM file begins with a little-endian 16-bit code offset.
+The bytes between offset 2 and the code offset are two-byte Shift-JIS dictionary
+entries.
 
 The interpreter dispatches opcodes `0x30` through `0x7f`. Juice structurally
 walks the complete instruction stream so it can distinguish instructions from
@@ -33,7 +36,7 @@ Mode 1 payload tokens are:
 | otherwise | raw two-byte Shift-JIS character |
 
 The two dictionary ranges address up to 168 entries. Mode 2 stores printable
-single-byte ASCII directly.
+single-byte ASCII directly and uses the same `04` newline control as mode 1.
 
 ## Layout and relocation metadata
 
@@ -84,3 +87,6 @@ and native local address fields. This permits translation, exact unchanged
 round trips, and changed-length relocation without claiming semantic names for
 the surrounding commands. Future opcode parsers can replace individual
 `(raw ...)` regions incrementally while retaining the same layout metadata.
+The structural layouts and relocation fields exercised by Fermion are validated
+across its corpus, but semantic opcode names beyond text and the
+scenario-loading commands above remain future work.

--- a/src/auto_detect.cpp
+++ b/src/auto_detect.cpp
@@ -46,6 +46,11 @@ static size_t gm_text_end(const std::vector<uint8_t>& bytes, size_t start,
         uint8_t byte = bytes[pos];
 
         if (mode == 2) {
+            if (byte == 0x04) {
+                pos++;
+                continue;
+            }
+
             if (byte < 0x20 || byte > 0x7e) {
                 return 0;
             }

--- a/src/auto_detect.cpp
+++ b/src/auto_detect.cpp
@@ -19,6 +19,123 @@
 #include "auto_detect.h"
 
 #include <algorithm>
+#include <cctype>
+#include <string>
+
+static bool valid_sjis_pair(uint8_t lead, uint8_t trail) {
+    bool valid_lead = (lead >= 0x81 && lead <= 0x9f) ||
+                      (lead >= 0xe0 && lead <= 0xef);
+    bool valid_trail = trail >= 0x40 && trail <= 0xfc && trail != 0x7f;
+    return valid_lead && valid_trail;
+}
+
+// Return the byte after a structurally valid, self-delimiting GM text record.
+// This deliberately does not decode text; auto-detection must work without a
+// selected charset.
+static size_t gm_text_end(const std::vector<uint8_t>& bytes, size_t start,
+                          size_t dict_entries) {
+    if (start + 2 >= bytes.size() || bytes[start] != 0x4a ||
+        (bytes[start + 1] != 1 && bytes[start + 1] != 2)) {
+        return 0;
+    }
+
+    int mode = bytes[start + 1];
+    size_t pos = start + 2;
+
+    while (pos < bytes.size() && bytes[pos] != 0) {
+        uint8_t byte = bytes[pos];
+
+        if (mode == 2) {
+            if (byte < 0x20 || byte > 0x7e) {
+                return 0;
+            }
+
+            pos++;
+        } else if (byte == 0x04) {
+            pos++;
+        } else if (byte >= 0x18 && byte <= 0x7f) {
+            if (static_cast<size_t>(byte - 0x18) >= dict_entries) {
+                return 0;
+            }
+
+            pos++;
+        } else if (byte >= 0xa0 && byte <= 0xdf) {
+            if (static_cast<size_t>(byte - 0x38) >= dict_entries) {
+                return 0;
+            }
+
+            pos++;
+        } else {
+            if (pos + 1 >= bytes.size() || !valid_sjis_pair(byte, bytes[pos + 1])) {
+                return 0;
+            }
+
+            pos += 2;
+        }
+    }
+
+    return pos < bytes.size() ? pos + 1 : 0;
+}
+
+static bool has_gm_startup_signature(const std::vector<uint8_t>& bytes, size_t code_start) {
+    // Fermion's entry scenario begins by loading SYSTEM.MLL:
+    //   6e 11 "system.mll" 00 00
+    if (code_start + 7 >= bytes.size() || bytes[code_start] != 0x6e ||
+        bytes[code_start + 1] != 0x11) {
+        return false;
+    }
+
+    size_t end = code_start + 2;
+
+    while (end < bytes.size() && end - code_start <= 64 && bytes[end] != 0) {
+        if (bytes[end] < 0x20 || bytes[end] > 0x7e) {
+            return false;
+        }
+
+        end++;
+    }
+
+    if (end + 1 >= bytes.size() || bytes[end] != 0 || bytes[end + 1] != 0) {
+        return false;
+    }
+
+    std::string name(bytes.begin() + code_start + 2, bytes.begin() + end);
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return name.size() >= 4 && name.substr(name.size() - 4) == ".mll";
+}
+
+static bool looks_like_gm(const std::vector<uint8_t>& bytes, size_t code_start,
+                          size_t dict_entries) {
+    if (has_gm_startup_signature(bytes, code_start)) {
+        return true;
+    }
+
+    int records = 0;
+
+    for (size_t pos = code_start; pos + 2 < bytes.size();) {
+        size_t end = gm_text_end(bytes, pos, dict_entries);
+
+        if (end != 0) {
+            // Empty text commands are valid, but too weak to identify an
+            // engine on their own.
+            if (end > pos + 3) {
+                records++;
+            }
+
+            if (records >= 2) {
+                return true;
+            }
+
+            pos = end;
+        } else {
+            pos++;
+        }
+    }
+
+    return false;
+}
 
 // score a byte sequence for AI5 vs AI1 structural markers.
 // scans the given range and returns positive if AI5 markers dominate,
@@ -120,6 +237,9 @@ EngineType detect_engine(const std::vector<uint8_t>& bytes) {
     uint16_t offset = static_cast<uint16_t>(bytes[0] | (bytes[1] << 8));
 
     if (offset >= 2 && offset <= bytes.size() && (offset - 2) % 2 == 0) {
+        if (looks_like_gm(bytes, offset, (offset - 2) / 2)) {
+            return EngineType::GM;
+        }
 
         // the offset check alone produces false positives for AI1 files whose
         // first 2 bytes coincidentally form a valid-looking offset.

--- a/src/auto_detect.h
+++ b/src/auto_detect.h
@@ -24,5 +24,5 @@
 #include <vector>
 
 // detect engine type from raw MES file bytes
-// checks ADV signature (last 2 bytes FF FE), then AI5 dictionary offset, then AI1 fallback
+// checks ADV signature, General Message structure, AI5 dictionary structure, then AI1 fallback
 EngineType detect_engine(const std::vector<uint8_t>& bytes);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -166,6 +166,8 @@ void Config::set_engine(const std::string& name) {
         engine = EngineType::ADV;
     } else if (upper == "AI5WIN") {
         engine = EngineType::AI5WIN;
+    } else if (upper == "GM" || upper == "GENERAL-MESSAGE" || upper == "GENERAL_MESSAGE") {
+        engine = EngineType::GM;
     } else {
         throw std::runtime_error("unknown engine type: " + name);
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -56,7 +56,10 @@ void Config::use_preset(const std::string& name) {
         return;
     }
 
-    if (lower == "angel") {
+    if (lower == "fermion") {
+        engine = EngineType::GM;
+
+    } else if (lower == "angel") {
         engine = EngineType::AI1;
     } else if (lower == "deja") {
         engine = EngineType::AI1;
@@ -246,6 +249,7 @@ std::vector<PresetInfo> get_presets() {
         {"dk3",    "Dragon Knight 3"},
         {"dk4",    "Dragon Knight 4"},
         {"elle",   "ELLE"},
+        {"fermion", "Fermion: Mirai kara no Houmonsha"},
         {"foxy",   "Foxy"},
         {"foxy2",  "Foxy 2"},
         {"isaku",  "Isaku"},

--- a/src/config.h
+++ b/src/config.h
@@ -29,7 +29,8 @@ enum class EngineType {
     AI5,
     AI1,
     ADV,
-    AI5WIN
+    AI5WIN,
+    GM
 };
 
 // protagonist fusion specification

--- a/src/engine/ai5/loader.cpp
+++ b/src/engine/ai5/loader.cpp
@@ -501,6 +501,7 @@ static AstNode fuse_meta(const AstNode& node, const Config& cfg) {
         case EngineType::AI1: engine_name = "AI1"; break;
         case EngineType::ADV: engine_name = "ADV"; break;
         case EngineType::AI5WIN: engine_name = "AI5WIN"; break;
+        case EngineType::GM: engine_name = "GM"; break;
     }
 
     meta_entries.push_back(AstNode::make_list("engine", {

--- a/src/engine/gm/compiler.cpp
+++ b/src/engine/gm/compiler.cpp
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #include "compiler.h"
 #include "../../byte_writer.h"
@@ -338,15 +346,15 @@ std::vector<uint8_t> compile_mes(const AstNode& ast, Config& cfg) {
         }
     }
 
+    if (layout.present && span_index != layout.spans.size()) {
+        throw std::runtime_error("gm: fewer code nodes than layout spans");
+    }
+
+    if (out.size() > 0x10000) {
+        throw std::runtime_error("gm: compiled file exceeds the 16-bit address space");
+    }
+
     if (layout.present) {
-        if (span_index != layout.spans.size()) {
-            throw std::runtime_error("gm: fewer code nodes than layout spans");
-        }
-
-        if (out.size() > 0x10000) {
-            throw std::runtime_error("gm: compiled file exceeds the 16-bit address space");
-        }
-
         apply_relocations(out, layout, output_spans);
     }
 

--- a/src/engine/gm/compiler.cpp
+++ b/src/engine/gm/compiler.cpp
@@ -223,8 +223,13 @@ void emit_text(ByteWriter& out, const AstNode& node, const Charset& cs,
 
     if (mode == 2) {
         for (unsigned char byte : node.children[1].str_val) {
+            if (byte == '\n') {
+                out.emit(0x04);
+                continue;
+            }
+
             if (byte < 0x20 || byte > 0x7e) {
-                throw std::runtime_error("gm: mode 2 text only supports printable ASCII");
+                throw std::runtime_error("gm: mode 2 text only supports printable ASCII and newlines");
             }
 
             out.emit(byte);

--- a/src/engine/gm/compiler.cpp
+++ b/src/engine/gm/compiler.cpp
@@ -1,0 +1,193 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#include "compiler.h"
+#include "../../byte_writer.h"
+#include "../../charset.h"
+#include "../../utf8.h"
+
+#include <stdexcept>
+#include <unordered_map>
+
+namespace gm {
+
+namespace {
+
+uint16_t pair_key(int first, int second) {
+    return static_cast<uint16_t>((first << 8) | second);
+}
+
+std::vector<std::vector<int>> read_dict(const AstNode& ast, const Charset& cs) {
+    std::vector<std::vector<int>> dict;
+
+    for (const auto& node : ast.children) {
+        if (!node.is_list("dict")) {
+            continue;
+        }
+
+        for (const auto& entry : node.children) {
+            if (entry.is_character()) {
+                auto sjis = cs.char_to_sjis(entry.char_val);
+
+                if (!sjis.has_value() || sjis->size() != 2) {
+                    throw std::runtime_error("gm: dictionary character is not double-byte SJIS");
+                }
+
+                dict.push_back(*sjis);
+                continue;
+            }
+
+            const AstNode* raw = &entry;
+
+            if (entry.is_quote() && !entry.children.empty()) {
+                raw = &entry.children[0];
+            }
+
+            if (!raw->is_list("_sjis_") || raw->children.size() != 2 ||
+                !raw->children[0].is_integer() || !raw->children[1].is_integer()) {
+                throw std::runtime_error("gm: malformed dictionary entry");
+            }
+
+            if (raw->children[0].int_val < 0 || raw->children[0].int_val > 255 ||
+                raw->children[1].int_val < 0 || raw->children[1].int_val > 255) {
+                throw std::runtime_error("gm: dictionary bytes must be from 0 to 255");
+            }
+
+            dict.push_back({raw->children[0].int_val, raw->children[1].int_val});
+        }
+
+        break;
+    }
+
+    if (dict.size() > 168) {
+        throw std::runtime_error("gm: dictionary exceeds the 168 encodable entries");
+    }
+
+    return dict;
+}
+
+void emit_header(ByteWriter& out, const std::vector<std::vector<int>>& dict) {
+    uint16_t offset = static_cast<uint16_t>(2 + dict.size() * 2);
+    out.emit_u16_le(offset);
+
+    for (const auto& pair : dict) {
+        out.emit(static_cast<uint8_t>(pair[0]));
+        out.emit(static_cast<uint8_t>(pair[1]));
+    }
+}
+
+void emit_text(ByteWriter& out, const AstNode& node, const Charset& cs,
+               const std::vector<std::vector<int>>& dict) {
+    if (node.children.size() != 2 || !node.children[0].is_integer() ||
+        !node.children[1].is_string()) {
+        throw std::runtime_error("gm: expected (gm-text MODE \"text\")");
+    }
+
+    int mode = node.children[0].int_val;
+
+    if (mode != 1 && mode != 2) {
+        throw std::runtime_error("gm: text mode must be 1 or 2");
+    }
+
+    out.emit(0x4a);
+    out.emit(static_cast<uint8_t>(mode));
+
+    if (mode == 2) {
+        for (unsigned char byte : node.children[1].str_val) {
+            if (byte < 0x20 || byte > 0x7e) {
+                throw std::runtime_error("gm: mode 2 text only supports printable ASCII");
+            }
+
+            out.emit(byte);
+        }
+    } else {
+        std::unordered_map<uint16_t, size_t> lookup;
+
+        for (size_t i = 0; i < dict.size(); i++) {
+            lookup.emplace(pair_key(dict[i][0], dict[i][1]), i);
+        }
+
+        for (char32_t ch : utf8_to_codepoints(node.children[1].str_val)) {
+            if (ch == U'\n') {
+                out.emit(0x04);
+                continue;
+            }
+
+            auto sjis = cs.char_to_sjis(ch);
+
+            if (!sjis.has_value() || sjis->size() != 2) {
+                throw std::runtime_error("gm: mode 1 text requires double-byte SJIS characters");
+            }
+
+            auto found = lookup.find(pair_key((*sjis)[0], (*sjis)[1]));
+
+            if (found == lookup.end()) {
+                out.emit(static_cast<uint8_t>((*sjis)[0]));
+                out.emit(static_cast<uint8_t>((*sjis)[1]));
+            } else if (found->second < 104) {
+                out.emit(static_cast<uint8_t>(0x18 + found->second));
+            } else {
+                out.emit(static_cast<uint8_t>(0x38 + found->second));
+            }
+        }
+    }
+
+    out.emit(0x00);
+}
+
+} // namespace
+
+std::vector<uint8_t> compile_mes(const AstNode& ast, Config& cfg) {
+    for (const auto& node : ast.children) {
+        if (!node.is_list("meta")) {
+            continue;
+        }
+
+        for (const auto& entry : node.children) {
+            if (entry.is_list("charset") && !entry.children.empty() &&
+                entry.children[0].is_string()) {
+                cfg.charset_name = entry.children[0].str_val;
+            }
+        }
+
+        break;
+    }
+
+    Charset cs;
+    cs.load(cfg.charset_name);
+    auto dict = read_dict(ast, cs);
+
+    ByteWriter out;
+    emit_header(out, dict);
+
+    for (const auto& node : ast.children) {
+        if (node.is_list("meta") || node.is_list("dict")) {
+            continue;
+        }
+
+        if (node.is_list("raw")) {
+            for (const auto& byte : node.children) {
+                if (!byte.is_integer() || byte.int_val < 0 || byte.int_val > 255) {
+                    throw std::runtime_error("gm: raw byte must be an integer from 0 to 255");
+                }
+
+                out.emit(static_cast<uint8_t>(byte.int_val));
+            }
+        } else if (node.is_list("gm-text")) {
+            emit_text(out, node, cs, dict);
+        } else {
+            throw std::runtime_error("gm compiler: unsupported node: " + node.tag);
+        }
+    }
+
+    return out.take_data();
+}
+
+} // namespace gm

--- a/src/engine/gm/compiler.cpp
+++ b/src/engine/gm/compiler.cpp
@@ -15,10 +15,132 @@
 
 #include <stdexcept>
 #include <unordered_map>
+#include <vector>
 
 namespace gm {
 
 namespace {
+
+struct SourceSpan {
+    size_t start;
+    size_t end;
+};
+
+struct OutputSpan {
+    size_t start;
+    size_t end;
+};
+
+struct Relocation {
+    size_t field;
+    uint16_t target;
+};
+
+struct Layout {
+    bool present = false;
+    std::vector<SourceSpan> spans;
+    std::vector<Relocation> relocations;
+};
+
+size_t layout_integer(const AstNode& node, const std::string& what,
+                      size_t maximum) {
+    if (!node.is_integer() || node.int_val < 0 ||
+        static_cast<size_t>(node.int_val) > maximum) {
+        throw std::runtime_error("gm: " + what + " is out of range");
+    }
+
+    return static_cast<size_t>(node.int_val);
+}
+
+Layout read_layout(const AstNode& ast) {
+    Layout layout;
+
+    for (const auto& node : ast.children) {
+        if (!node.is_list("gm-layout")) {
+            continue;
+        }
+
+        if (layout.present) {
+            throw std::runtime_error("gm: multiple gm-layout nodes");
+        }
+
+        layout.present = true;
+
+        for (const auto& entry : node.children) {
+            if (entry.is_list("span") && entry.children.size() == 2) {
+                size_t start = layout_integer(entry.children[0], "span start", 0xffff);
+                size_t end = layout_integer(entry.children[1], "span end", 0x10000);
+
+                if (start >= end) {
+                    throw std::runtime_error("gm: layout span must be non-empty");
+                }
+
+                if (!layout.spans.empty() && layout.spans.back().end != start) {
+                    throw std::runtime_error("gm: layout spans must be contiguous");
+                }
+
+                layout.spans.push_back({start, end});
+            } else if (entry.is_list("reloc") && entry.children.size() == 2) {
+                size_t field = layout_integer(entry.children[0], "relocation field", 0xffff);
+                size_t target = layout_integer(entry.children[1], "relocation target", 0xffff);
+                layout.relocations.push_back({field, static_cast<uint16_t>(target)});
+            } else {
+                throw std::runtime_error("gm: malformed gm-layout entry");
+            }
+        }
+    }
+
+    return layout;
+}
+
+size_t remap_position(size_t source, const std::vector<SourceSpan>& old_spans,
+                      const std::vector<OutputSpan>& new_spans) {
+    for (size_t i = 0; i < old_spans.size(); i++) {
+        const auto& old_span = old_spans[i];
+
+        if (source < old_span.start || source >= old_span.end) {
+            continue;
+        }
+
+        size_t offset = source - old_span.start;
+        size_t old_size = old_span.end - old_span.start;
+        size_t new_size = new_spans[i].end - new_spans[i].start;
+
+        if (old_size != new_size && offset != 0) {
+            throw std::runtime_error(
+                "gm: relocation points inside a resized source node");
+        }
+
+        if (offset >= new_size) {
+            throw std::runtime_error("gm: relocation no longer fits its source node");
+        }
+
+        return new_spans[i].start + offset;
+    }
+
+    throw std::runtime_error("gm: relocation is outside the recorded source spans");
+}
+
+void apply_relocations(ByteWriter& out, const Layout& layout,
+                       const std::vector<OutputSpan>& output_spans) {
+    for (const auto& relocation : layout.relocations) {
+        size_t field = remap_position(relocation.field, layout.spans, output_spans);
+        size_t field_end = remap_position(relocation.field + 1,
+                                          layout.spans, output_spans);
+        size_t target = remap_position(relocation.target,
+                                       layout.spans, output_spans);
+
+        if (field_end != field + 1) {
+            throw std::runtime_error("gm: relocated control field is not contiguous");
+        }
+
+        if (target > 0xffff) {
+            throw std::runtime_error("gm: relocated control target exceeds 16 bits");
+        }
+
+        out.write_u16_le_at(field, static_cast<uint16_t>(target));
+    }
+}
 
 uint16_t pair_key(int first, int second) {
     return static_cast<uint16_t>((first << 8) | second);
@@ -163,14 +285,20 @@ std::vector<uint8_t> compile_mes(const AstNode& ast, Config& cfg) {
     Charset cs;
     cs.load(cfg.charset_name);
     auto dict = read_dict(ast, cs);
+    auto layout = read_layout(ast);
 
     ByteWriter out;
     emit_header(out, dict);
+    std::vector<OutputSpan> output_spans;
+    size_t span_index = 0;
 
     for (const auto& node : ast.children) {
-        if (node.is_list("meta") || node.is_list("dict")) {
+        if (node.is_list("meta") || node.is_list("dict") ||
+            node.is_list("gm-layout")) {
             continue;
         }
+
+        size_t output_start = out.size();
 
         if (node.is_list("raw")) {
             for (const auto& byte : node.children) {
@@ -185,6 +313,36 @@ std::vector<uint8_t> compile_mes(const AstNode& ast, Config& cfg) {
         } else {
             throw std::runtime_error("gm compiler: unsupported node: " + node.tag);
         }
+
+        size_t output_end = out.size();
+
+        if (layout.present) {
+            if (span_index >= layout.spans.size()) {
+                throw std::runtime_error("gm: more code nodes than layout spans");
+            }
+
+            const auto& source = layout.spans[span_index];
+
+            if (node.is_list("raw") &&
+                output_end - output_start != source.end - source.start) {
+                throw std::runtime_error("gm: raw nodes with layout metadata cannot change length");
+            }
+
+            output_spans.push_back({output_start, output_end});
+            span_index++;
+        }
+    }
+
+    if (layout.present) {
+        if (span_index != layout.spans.size()) {
+            throw std::runtime_error("gm: fewer code nodes than layout spans");
+        }
+
+        if (out.size() > 0x10000) {
+            throw std::runtime_error("gm: compiled file exceeds the 16-bit address space");
+        }
+
+        apply_relocations(out, layout, output_spans);
     }
 
     return out.take_data();

--- a/src/engine/gm/compiler.h
+++ b/src/engine/gm/compiler.h
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #pragma once
 

--- a/src/engine/gm/compiler.h
+++ b/src/engine/gm/compiler.h
@@ -1,0 +1,23 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include "../../ast.h"
+#include "../../config.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace gm {
+
+std::vector<uint8_t> compile_mes(const AstNode& ast, Config& cfg);
+
+} // namespace gm

--- a/src/engine/gm/loader.cpp
+++ b/src/engine/gm/loader.cpp
@@ -10,9 +10,11 @@
 
 #include "loader.h"
 #include "opener.h"
+#include "walker.h"
 #include "../../charset.h"
 #include "../../utf8.h"
 
+#include <iterator>
 #include <optional>
 #include <vector>
 
@@ -125,9 +127,18 @@ AstNode make_dict(const std::vector<std::vector<int>>& dict, const Config& cfg,
     return AstNode::make_list("dict", std::move(entries));
 }
 
-void flush_raw(std::vector<AstNode>& nodes, std::vector<AstNode>& raw) {
+void append_span(std::vector<AstNode>& layout, size_t start, size_t end) {
+    layout.push_back(AstNode::make_list("span", {
+        AstNode::make_integer(static_cast<int32_t>(start)),
+        AstNode::make_integer(static_cast<int32_t>(end))
+    }));
+}
+
+void flush_raw(std::vector<AstNode>& nodes, std::vector<AstNode>& raw,
+               std::vector<AstNode>& layout, size_t start, size_t end) {
     if (!raw.empty()) {
         nodes.push_back(AstNode::make_list("raw", std::move(raw)));
+        append_span(layout, start, end);
         raw.clear();
     }
 }
@@ -150,27 +161,54 @@ AstNode load_mes(const std::string& path, Config& cfg) {
     }));
     nodes.push_back(make_dict(mes.dictionary, cfg, cs));
 
+    size_t code_base = 2 + mes.dictionary.size() * 2;
+    auto walk = walk_code(mes.code, code_base);
+    std::vector<AstNode> code_nodes;
+    std::vector<AstNode> layout;
     std::vector<AstNode> raw;
-    size_t pos = 0;
+    size_t raw_start = 0;
+    size_t raw_end = 0;
 
-    while (pos < mes.code.size()) {
-        auto text = parse_text(mes.code, pos, mes.dictionary, cs);
+    for (const auto& instruction : walk.instructions) {
+        size_t start = instruction.start - code_base;
+        size_t end = instruction.end - code_base;
+        auto text = instruction.opcode == 0x4a
+            ? parse_text(mes.code, start, mes.dictionary, cs)
+            : std::nullopt;
 
-        if (!text.has_value() || !cfg.decode) {
-            raw.push_back(AstNode::make_integer(mes.code[pos]));
-            pos++;
+        if (!text.has_value() || text->end != end || !cfg.decode) {
+            if (raw.empty()) {
+                raw_start = instruction.start;
+            }
+
+            for (size_t pos = start; pos < end; pos++) {
+                raw.push_back(AstNode::make_integer(mes.code[pos]));
+            }
+
+            raw_end = instruction.end;
             continue;
         }
 
-        flush_raw(nodes, raw);
-        nodes.push_back(AstNode::make_list("gm-text", {
+        flush_raw(code_nodes, raw, layout, raw_start, raw_end);
+        code_nodes.push_back(AstNode::make_list("gm-text", {
             AstNode::make_integer(text->mode),
             AstNode::make_string(text->text)
         }));
-        pos = text->end;
+        append_span(layout, instruction.start, instruction.end);
     }
 
-    flush_raw(nodes, raw);
+    flush_raw(code_nodes, raw, layout, raw_start, raw_end);
+
+    for (const auto& relocation : walk.relocations) {
+        layout.push_back(AstNode::make_list("reloc", {
+            AstNode::make_integer(static_cast<int32_t>(relocation.field)),
+            AstNode::make_integer(relocation.target)
+        }));
+    }
+
+    nodes.push_back(AstNode::make_list("gm-layout", std::move(layout)));
+    nodes.insert(nodes.end(), std::make_move_iterator(code_nodes.begin()),
+                 std::make_move_iterator(code_nodes.end()));
     return AstNode::make_list("mes", std::move(nodes));
 }
 

--- a/src/engine/gm/loader.cpp
+++ b/src/engine/gm/loader.cpp
@@ -51,6 +51,12 @@ std::optional<TextRecord> parse_text(const std::vector<uint8_t>& code, size_t st
         uint8_t byte = code[pos];
 
         if (mode == 2) {
+            if (byte == 0x04) {
+                text.push_back('\n');
+                pos++;
+                continue;
+            }
+
             if (byte < 0x20 || byte > 0x7e) {
                 return std::nullopt;
             }

--- a/src/engine/gm/loader.cpp
+++ b/src/engine/gm/loader.cpp
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #include "loader.h"
 #include "opener.h"

--- a/src/engine/gm/loader.cpp
+++ b/src/engine/gm/loader.cpp
@@ -1,0 +1,177 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#include "loader.h"
+#include "opener.h"
+#include "../../charset.h"
+#include "../../utf8.h"
+
+#include <optional>
+#include <vector>
+
+namespace gm {
+
+namespace {
+
+struct TextRecord {
+    size_t end;
+    int mode;
+    std::string text;
+};
+
+bool is_sjis_pair(uint8_t lead, uint8_t trail) {
+    bool valid_lead = (lead >= 0x81 && lead <= 0x9f) ||
+                      (lead >= 0xe0 && lead <= 0xef);
+    bool valid_trail = trail >= 0x40 && trail <= 0xfc && trail != 0x7f;
+    return valid_lead && valid_trail;
+}
+
+std::optional<TextRecord> parse_text(const std::vector<uint8_t>& code, size_t start,
+                                     const std::vector<std::vector<int>>& dict,
+                                     const Charset& cs) {
+    if (start + 2 >= code.size() || code[start] != 0x4a ||
+        (code[start + 1] != 1 && code[start + 1] != 2)) {
+        return std::nullopt;
+    }
+
+    int mode = code[start + 1];
+    size_t pos = start + 2;
+    std::string text;
+
+    while (pos < code.size() && code[pos] != 0) {
+        uint8_t byte = code[pos];
+
+        if (mode == 2) {
+            if (byte < 0x20 || byte > 0x7e) {
+                return std::nullopt;
+            }
+
+            text.push_back(static_cast<char>(byte));
+            pos++;
+            continue;
+        }
+
+        if (byte == 0x04) {
+            text.push_back('\n');
+            pos++;
+            continue;
+        }
+
+        int dict_index = -1;
+
+        if (byte >= 0x18 && byte <= 0x7f) {
+            dict_index = byte - 0x18;
+        } else if (byte >= 0xa0 && byte <= 0xdf) {
+            dict_index = byte - 0x38;
+        }
+
+        std::vector<int> sjis;
+
+        if (dict_index >= 0) {
+            if (dict_index >= static_cast<int>(dict.size())) {
+                return std::nullopt;
+            }
+
+            sjis = dict[dict_index];
+            pos++;
+        } else {
+            if (pos + 1 >= code.size() || !is_sjis_pair(byte, code[pos + 1])) {
+                return std::nullopt;
+            }
+
+            sjis = {byte, code[pos + 1]};
+            pos += 2;
+        }
+
+        auto decoded = cs.sjis_to_char(sjis);
+
+        if (!decoded.has_value()) {
+            return std::nullopt;
+        }
+
+        text += char32_to_utf8(*decoded);
+    }
+
+    if (pos >= code.size()) {
+        return std::nullopt;
+    }
+
+    return TextRecord{pos + 1, mode, std::move(text)};
+}
+
+AstNode make_dict(const std::vector<std::vector<int>>& dict, const Config& cfg,
+                  const Charset& cs) {
+    std::vector<AstNode> entries;
+
+    for (const auto& pair : dict) {
+        auto decoded = cs.sjis_to_char(pair);
+
+        if (cfg.decode && decoded.has_value()) {
+            entries.push_back(AstNode::make_character(*decoded));
+        } else {
+            entries.push_back(AstNode::make_quote(AstNode::make_list("_sjis_", {
+                AstNode::make_integer(pair[0]), AstNode::make_integer(pair[1])
+            })));
+        }
+    }
+
+    return AstNode::make_list("dict", std::move(entries));
+}
+
+void flush_raw(std::vector<AstNode>& nodes, std::vector<AstNode>& raw) {
+    if (!raw.empty()) {
+        nodes.push_back(AstNode::make_list("raw", std::move(raw)));
+        raw.clear();
+    }
+}
+
+} // namespace
+
+AstNode load_mes(const std::string& path, Config& cfg) {
+    Charset cs;
+    cs.load(cfg.charset_name);
+    auto mes = open_mes(path);
+
+    std::vector<AstNode> nodes;
+    nodes.push_back(AstNode::make_list("meta", {
+        AstNode::make_list("engine", {
+            AstNode::make_quote(AstNode::make_symbol("GM"))
+        }),
+        AstNode::make_list("charset", {
+            AstNode::make_string(cfg.charset_name)
+        })
+    }));
+    nodes.push_back(make_dict(mes.dictionary, cfg, cs));
+
+    std::vector<AstNode> raw;
+    size_t pos = 0;
+
+    while (pos < mes.code.size()) {
+        auto text = parse_text(mes.code, pos, mes.dictionary, cs);
+
+        if (!text.has_value() || !cfg.decode) {
+            raw.push_back(AstNode::make_integer(mes.code[pos]));
+            pos++;
+            continue;
+        }
+
+        flush_raw(nodes, raw);
+        nodes.push_back(AstNode::make_list("gm-text", {
+            AstNode::make_integer(text->mode),
+            AstNode::make_string(text->text)
+        }));
+        pos = text->end;
+    }
+
+    flush_raw(nodes, raw);
+    return AstNode::make_list("mes", std::move(nodes));
+}
+
+} // namespace gm

--- a/src/engine/gm/loader.h
+++ b/src/engine/gm/loader.h
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #pragma once
 

--- a/src/engine/gm/loader.h
+++ b/src/engine/gm/loader.h
@@ -1,0 +1,25 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include "../../ast.h"
+#include "../../config.h"
+
+#include <string>
+
+namespace gm {
+
+// General Message is only partially understood. The loader decodes its
+// self-delimiting text opcode and preserves every other byte in (raw ...)
+// nodes, so a decompile/compile cycle remains lossless.
+AstNode load_mes(const std::string& path, Config& cfg);
+
+} // namespace gm

--- a/src/engine/gm/opener.cpp
+++ b/src/engine/gm/opener.cpp
@@ -1,0 +1,52 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#include "opener.h"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace gm {
+
+MesFile open_mes(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+
+    if (!file.is_open()) {
+        throw std::runtime_error("cannot open file: " + path);
+    }
+
+    std::vector<uint8_t> bytes(
+        (std::istreambuf_iterator<char>(file)),
+        std::istreambuf_iterator<char>());
+    return open_mes_bytes(bytes);
+}
+
+MesFile open_mes_bytes(const std::vector<uint8_t>& bytes) {
+    if (bytes.size() < 2) {
+        throw std::runtime_error("GM MES file too small (< 2 bytes)");
+    }
+
+    uint16_t offset = static_cast<uint16_t>(bytes[0] | (bytes[1] << 8));
+
+    if (offset < 2 || offset > bytes.size() || (offset - 2) % 2 != 0) {
+        throw std::runtime_error("invalid GM MES dictionary offset");
+    }
+
+    MesFile mes;
+
+    for (size_t i = 2; i < offset; i += 2) {
+        mes.dictionary.push_back({bytes[i], bytes[i + 1]});
+    }
+
+    mes.code.assign(bytes.begin() + offset, bytes.end());
+    return mes;
+}
+
+} // namespace gm

--- a/src/engine/gm/opener.cpp
+++ b/src/engine/gm/opener.cpp
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #include "opener.h"
 

--- a/src/engine/gm/opener.h
+++ b/src/engine/gm/opener.h
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #pragma once
 

--- a/src/engine/gm/opener.h
+++ b/src/engine/gm/opener.h
@@ -1,0 +1,23 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include "../engine.h"
+
+#include <string>
+#include <vector>
+
+namespace gm {
+
+MesFile open_mes(const std::string& path);
+MesFile open_mes_bytes(const std::vector<uint8_t>& bytes);
+
+} // namespace gm

--- a/src/engine/gm/walker.cpp
+++ b/src/engine/gm/walker.cpp
@@ -1,0 +1,569 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#include "walker.h"
+
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace gm {
+
+namespace {
+
+struct Expression {
+    size_t end;
+    bool pure_literal = false;
+    uint32_t literal = 0;
+    size_t literal_offset = 0;
+    size_t literal_width = 0;
+};
+
+struct PendingRelocation {
+    size_t field;
+    uint16_t target;
+    bool required_local;
+};
+
+struct ParsedInstruction {
+    InstructionSpan span;
+    std::vector<PendingRelocation> relocations;
+};
+
+class Walker {
+public:
+    Walker(const std::vector<uint8_t>& code, size_t code_base)
+        : code_(code), base_(code_base), end_(code_base + code.size()) {
+        if (end_ < base_) {
+            throw std::runtime_error("gm: code range overflow");
+        }
+
+        if (end_ > 0x10000) {
+            throw std::runtime_error("gm: MES file exceeds the 16-bit address space");
+        }
+    }
+
+    WalkResult walk() {
+        WalkResult result;
+        std::vector<PendingRelocation> pending;
+        size_t pos = base_;
+
+        while (pos < end_) {
+            auto instruction = read_instruction(pos);
+
+            if (instruction.span.end <= pos) {
+                fail(pos, "instruction did not advance");
+            }
+
+            pos = instruction.span.end;
+            result.instructions.push_back(instruction.span);
+            pending.insert(pending.end(), instruction.relocations.begin(),
+                           instruction.relocations.end());
+        }
+
+        if (pos != end_) {
+            fail(pos, "instruction extends past the end of the MES code");
+        }
+
+        std::unordered_set<size_t> boundaries;
+
+        for (const auto& instruction : result.instructions) {
+            boundaries.insert(instruction.start);
+        }
+
+        for (const auto& relocation : pending) {
+            bool local = relocation.target >= base_ && relocation.target < end_;
+
+            if (relocation.required_local && !local) {
+                fail(relocation.field, "control target is outside the MES code");
+            }
+
+            if (local && boundaries.count(relocation.target) == 0) {
+                fail(relocation.field, "control target is not an instruction boundary");
+            }
+
+            if (local) {
+                result.relocations.push_back({relocation.field, relocation.target});
+            }
+        }
+
+        return result;
+    }
+
+private:
+    struct Operand {
+        size_t end;
+        bool literal = false;
+        uint32_t value = 0;
+        size_t width = 0;
+    };
+
+    [[noreturn]] void fail(size_t pos, const std::string& message) const {
+        std::ostringstream out;
+        out << "gm: 0x" << std::hex << std::setw(4) << std::setfill('0') << pos
+            << ": " << message;
+        throw std::runtime_error(out.str());
+    }
+
+    void require(size_t pos, size_t size, const std::string& what) const {
+        if (pos < base_ || pos > end_ || size > end_ - pos) {
+            fail(pos, "truncated " + what);
+        }
+    }
+
+    uint8_t byte(size_t pos, const std::string& what = "operand") const {
+        require(pos, 1, what);
+        return code_[pos - base_];
+    }
+
+    uint16_t u16(size_t pos) const {
+        require(pos, 2, "16-bit operand");
+        return static_cast<uint16_t>(code_[pos - base_] |
+                                     (code_[pos - base_ + 1] << 8));
+    }
+
+    size_t find_zero(size_t pos, const std::string& what) const {
+        while (pos < end_ && code_[pos - base_] != 0) {
+            pos++;
+        }
+
+        if (pos == end_) {
+            fail(pos, "unterminated " + what);
+        }
+
+        return pos;
+    }
+
+    size_t expect_zero(size_t pos, const std::string& what) const {
+        uint8_t found = byte(pos, what);
+
+        if (found != 0) {
+            std::ostringstream message;
+            message << "expected zero " << what << ", found 0x" << std::hex
+                    << std::setw(2) << std::setfill('0') << static_cast<int>(found);
+            fail(pos, message.str());
+        }
+
+        return pos + 1;
+    }
+
+    size_t read_reference(size_t pos) const {
+        require(pos, 3, "reference");
+        uint8_t token = byte(pos);
+
+        if (token < 5) {
+            fail(pos, "invalid reference token");
+        }
+
+        pos += 3;
+
+        if (token <= 0x0a) {
+            pos = read_expression(pos).end;
+        }
+
+        return pos;
+    }
+
+    Operand read_operand(size_t pos, bool initial) const {
+        uint8_t token = byte(pos, "expression operand");
+
+        if (initial && token == 0x32) {
+            require(pos, 5, "random-range operand");
+            return {pos + 5};
+        }
+
+        if (token >= 1 && token <= 4) {
+            require(pos + 1, token, "literal operand");
+            uint32_t value = 0;
+
+            for (size_t i = 0; i < token; i++) {
+                value |= static_cast<uint32_t>(byte(pos + 1 + i)) << (i * 8);
+            }
+
+            return {pos + 1 + token, true, value, token};
+        }
+
+        if (token >= 5) {
+            return {read_reference(pos)};
+        }
+
+        fail(pos, "zero is not an expression operand");
+    }
+
+    Expression read_expression(size_t pos) const {
+        size_t start = pos;
+
+        if (byte(pos, "expression") == 0) {
+            return {pos + 1};
+        }
+
+        auto operand = read_operand(pos, true);
+        pos = operand.end;
+        bool pure_literal = operand.literal;
+
+        while (true) {
+            uint8_t token = byte(pos, "expression terminator");
+
+            if (token == 0) {
+                Expression result{pos + 1};
+
+                if (pure_literal) {
+                    result.pure_literal = true;
+                    result.literal = operand.value;
+                    result.literal_offset = start + 1;
+                    result.literal_width = operand.width;
+                }
+
+                return result;
+            }
+
+            pure_literal = false;
+
+            if (token >= 0x20) {
+                pos++;
+            } else {
+                pos = read_operand(pos, false).end;
+            }
+        }
+    }
+
+    size_t read_params(size_t pos) const {
+        while (true) {
+            uint8_t token = byte(pos, "parameter list");
+
+            if (token == 0) {
+                return pos + 1;
+            }
+
+            if (token == 0x11) {
+                pos = find_zero(pos + 1, "literal-string parameter") + 1;
+            } else if (token == 0x0f) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after reference parameter");
+            } else {
+                pos = read_expression(pos).end;
+            }
+        }
+    }
+
+    size_t read_reference_list(size_t pos) const {
+        while (true) {
+            if (byte(pos, "reference list") == 0) {
+                return pos + 1;
+            }
+
+            pos = read_reference(pos);
+            pos = expect_zero(pos, "after reference");
+        }
+    }
+
+    size_t read_assignment(size_t pos) const {
+        pos = read_reference(pos);
+
+        while (true) {
+            if (byte(pos) == 0x0e) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after string reference");
+            } else {
+                pos = read_expression(pos).end;
+            }
+
+            while (byte(pos) == 0x31) {
+                require(pos, 2, "assignment stride");
+                pos += 2;
+            }
+
+            if (byte(pos) == 0) {
+                return pos + 1;
+            }
+
+            if (byte(pos) == 0x30) {
+                pos = read_reference(pos + 1);
+                return expect_zero(pos, "after assignment range");
+            }
+        }
+    }
+
+    void add_relocation(std::vector<PendingRelocation>& relocations, size_t field,
+                        bool required_local) const {
+        relocations.push_back({field, u16(field), required_local});
+    }
+
+    size_t read_3a(size_t pos, std::vector<PendingRelocation>& relocations) const {
+        uint8_t subtype = byte(pos, "opcode 0x3a subtype");
+        pos++;
+
+        if (subtype == 1) {
+            auto selector = read_expression(pos);
+            pos = selector.end;
+            pos = read_expression(pos).end;
+
+            if (selector.pure_literal && selector.literal == 1) {
+                for (size_t field = 0; field < 6; field++) {
+                    auto value = read_expression(pos);
+
+                    if (field == 4 && value.pure_literal &&
+                        value.literal_width == 2) {
+                        relocations.push_back({value.literal_offset,
+                                              static_cast<uint16_t>(value.literal), true});
+                    }
+
+                    pos = value.end;
+                }
+            }
+        } else if (subtype == 2 || subtype == 3 || subtype == 6) {
+            pos = read_reference(pos);
+            pos = expect_zero(pos, "after 0x3a reference");
+        } else if (subtype == 4) {
+            for (size_t i = 0; i < 9; i++) {
+                pos = read_expression(pos).end;
+            }
+        } else if (subtype == 5) {
+            for (size_t i = 0; i < 3; i++) {
+                pos = read_expression(pos).end;
+            }
+
+            for (size_t i = 0; i < 2; i++) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after 0x3a reference");
+            }
+        } else if (subtype == 7 || subtype == 8 || subtype == 9) {
+            pos = read_expression(pos).end;
+        } else if (subtype == 10) {
+            auto selector = read_expression(pos);
+            pos = selector.end;
+            size_t count = selector.pure_literal && selector.literal == 0 ? 7 : 6;
+
+            for (size_t i = 0; i < count; i++) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after 0x3a subtype 10 reference");
+            }
+
+            if (!selector.pure_literal && byte(pos) != 0) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after 0x3a subtype 10 reference");
+            }
+        } else if (subtype < 11 || subtype > 13) {
+            fail(pos - 1, "unknown opcode 0x3a subtype");
+        }
+
+        return expect_zero(pos, "after opcode 0x3a");
+    }
+
+    static bool no_operands(uint8_t opcode) {
+        switch (opcode) {
+            case 0x30: case 0x36: case 0x38: case 0x3d: case 0x41:
+            case 0x42: case 0x50: case 0x56: case 0x57: case 0x66:
+            case 0x69: case 0x70: case 0x7c: case 0x7f:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static bool generic_params(uint8_t opcode) {
+        switch (opcode) {
+            case 0x46: case 0x47: case 0x48: case 0x49: case 0x4c:
+            case 0x4d: case 0x4e: case 0x4f: case 0x51: case 0x52:
+            case 0x53: case 0x54: case 0x55: case 0x58: case 0x59:
+            case 0x5a: case 0x5b: case 0x5c: case 0x5d: case 0x5e:
+            case 0x5f: case 0x60: case 0x61: case 0x63: case 0x67:
+            case 0x6c: case 0x6d: case 0x6e: case 0x6f: case 0x74:
+            case 0x75: case 0x78: case 0x7a: case 0x7d:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    ParsedInstruction read_instruction(size_t start) const {
+        uint8_t opcode = byte(start, "opcode");
+        size_t pos = start + 1;
+        std::vector<PendingRelocation> relocations;
+
+        if (opcode == 0) {
+            return {{start, pos, opcode}, {}};
+        }
+
+        if (opcode < 0x30 || opcode > 0x7f) {
+            fail(start, "invalid GM opcode");
+        }
+
+        if (no_operands(opcode)) {
+            // Nothing to decode.
+        } else if (opcode == 0x31) {
+            require(pos, 4, "opcode 0x31 operands");
+            add_relocation(relocations, pos + 2, true);
+            pos = read_expression(pos + 4).end;
+        } else if (opcode == 0x32) {
+            require(pos, 4, "opcode 0x32 operands");
+            add_relocation(relocations, pos + 2, true);
+            pos += 4;
+        } else if (opcode == 0x33 || opcode == 0x34) {
+            add_relocation(relocations, pos, true);
+            pos = read_expression(pos + 2).end;
+        } else if (opcode == 0x35) {
+            add_relocation(relocations, pos, true);
+            pos += 2;
+
+            while (byte(pos) != 0) {
+                pos = read_expression(pos).end;
+            }
+
+            pos++;
+        } else if (opcode == 0x37) {
+            pos = read_expression(pos).end;
+        } else if (opcode == 0x39 || opcode == 0x3f || opcode == 0x40) {
+            require(pos, 4, "call targets");
+            add_relocation(relocations, pos, true);
+            add_relocation(relocations, pos + 2, false);
+            pos = read_expression(pos + 4).end;
+        } else if (opcode == 0x3a) {
+            pos = read_3a(pos, relocations);
+        } else if (opcode == 0x3b) {
+            pos = read_expression(pos).end;
+            pos = expect_zero(pos, "after opcode 0x3b");
+        } else if (opcode == 0x3c) {
+            require(pos, 5, "opcode 0x3c payload");
+            pos += 5;
+        } else if (opcode == 0x3e) {
+            require(pos, 1, "opcode 0x3e mode");
+            pos = expect_zero(pos + 1, "after opcode 0x3e");
+        } else if (opcode == 0x43) {
+            pos = read_assignment(pos);
+        } else if (opcode == 0x44) {
+            pos = read_reference(pos);
+            size_t field = pos;
+            uint16_t target = u16(field);
+            pos += 2;
+
+            if (byte(pos) == 0x0f) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after opcode 0x44 reference");
+            } else {
+                relocations.push_back({field, target, true});
+
+                if (target <= pos || target > end_) {
+                    fail(field, "invalid opcode 0x44 skip target");
+                }
+
+                pos = target;
+            }
+        } else if (opcode == 0x45) {
+            pos = read_reference(pos);
+            require(pos, 2, "opcode 0x45 source");
+
+            if (byte(pos + 1) >= 5) {
+                pos = read_reference(pos + 1);
+                pos = expect_zero(pos, "after opcode 0x45 reference");
+            } else {
+                size_t end = find_zero(pos, "opcode 0x45 inline source");
+                require(end + 1, 1, "opcode 0x45 trailing byte");
+                pos = end + 2;
+            }
+        } else if (opcode == 0x4a) {
+            uint8_t mode = byte(pos, "opcode 0x4a mode");
+
+            if (mode != 1 && mode != 2) {
+                fail(pos, "invalid opcode 0x4a mode");
+            }
+
+            pos = find_zero(pos + 1, "opcode 0x4a text") + 1;
+        } else if (opcode == 0x4b) {
+            pos = read_reference(pos);
+            require(pos, 2, "opcode 0x4b terminators");
+            pos += 2;
+        } else if (generic_params(opcode)) {
+            pos = read_params(pos);
+        } else if (opcode == 0x62) {
+            pos = expect_zero(pos, "after opcode 0x62");
+        } else if (opcode == 0x64) {
+            pos = read_reference(pos);
+            pos = expect_zero(pos, "after opcode 0x64 reference");
+            pos = expect_zero(pos, "after opcode 0x64");
+        } else if (opcode == 0x65 || opcode == 0x68 || opcode == 0x6a) {
+            pos = read_reference_list(pos);
+        } else if (opcode == 0x6b) {
+            auto selector = read_expression(pos);
+            pos = selector.end;
+
+            if (!selector.pure_literal || selector.literal > 9) {
+                fail(start, "opcode 0x6b selector is not a literal from 0 through 9");
+            }
+
+            if (selector.literal == 0 || selector.literal == 1 ||
+                selector.literal == 7 || selector.literal == 8) {
+                pos = expect_zero(pos, "after opcode 0x6b");
+            } else if (selector.literal == 2 || selector.literal == 3) {
+                pos = read_reference_list(pos);
+            } else {
+                pos = read_params(pos);
+            }
+        } else if (opcode == 0x71) {
+            auto selector = read_expression(pos);
+            pos = selector.end;
+
+            if (!selector.pure_literal || selector.literal > 2) {
+                fail(start, "opcode 0x71 selector is not a literal 0, 1, or 2");
+            }
+
+            if (selector.literal == 0) {
+                pos = read_reference(pos);
+                pos = expect_zero(pos, "after opcode 0x71 reference");
+                pos = expect_zero(pos, "after opcode 0x71");
+            } else if (selector.literal == 1) {
+                pos = read_expression(pos).end;
+                pos = expect_zero(pos, "after opcode 0x71");
+            } else {
+                pos = read_params(pos);
+            }
+        } else if (opcode == 0x72 || opcode == 0x73 || opcode == 0x7e) {
+            pos = read_expression(pos).end;
+            pos = read_reference(pos);
+            pos = expect_zero(pos, "after reference");
+            pos = read_expression(pos).end;
+            pos = expect_zero(pos, "after opcode");
+        } else if (opcode == 0x76 || opcode == 0x77) {
+            pos = read_expression(pos).end;
+            pos = read_expression(pos).end;
+            pos = expect_zero(pos, "after opcode");
+        } else if (opcode == 0x79) {
+            pos = read_expression(pos).end;
+            pos = read_reference_list(pos);
+        } else if (opcode == 0x7b) {
+            pos = read_reference(pos);
+            pos = expect_zero(pos, "after opcode 0x7b reference");
+            pos = read_params(pos);
+        } else {
+            fail(start, "unsupported GM opcode");
+        }
+
+        if (pos > end_) {
+            fail(start, "instruction extends past the end of the MES code");
+        }
+
+        return {{start, pos, opcode}, std::move(relocations)};
+    }
+
+    const std::vector<uint8_t>& code_;
+    size_t base_;
+    size_t end_;
+};
+
+} // namespace
+
+WalkResult walk_code(const std::vector<uint8_t>& code, size_t code_base) {
+    return Walker(code, code_base).walk();
+}
+
+} // namespace gm

--- a/src/engine/gm/walker.cpp
+++ b/src/engine/gm/walker.cpp
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #include "walker.h"
 

--- a/src/engine/gm/walker.h
+++ b/src/engine/gm/walker.h
@@ -7,6 +7,14 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
 
 #pragma once
 

--- a/src/engine/gm/walker.h
+++ b/src/engine/gm/walker.h
@@ -1,0 +1,39 @@
+//
+// lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+// Copyright (C) 2026 Fuzion
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace gm {
+
+struct InstructionSpan {
+    size_t start;
+    size_t end;
+    uint8_t opcode;
+};
+
+struct LocalRelocation {
+    size_t field;
+    uint16_t target;
+};
+
+struct WalkResult {
+    std::vector<InstructionSpan> instructions;
+    std::vector<LocalRelocation> relocations;
+};
+
+// Decode the complete GM instruction stream. All returned positions are
+// absolute MES file offsets, including the dictionary/header prefix.
+WalkResult walk_code(const std::vector<uint8_t>& code, size_t code_base);
+
+} // namespace gm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,8 @@
 #include "engine/ai1/compiler.h"
 #include "engine/ai5/compiler.h"
 #include "engine/adv/compiler.h"
+#include "engine/gm/loader.h"
+#include "engine/gm/compiler.h"
 
 #include <filesystem>
 #include <fstream>
@@ -66,7 +68,7 @@ static void print_usage() {
     std::cerr << "  -f, --force         force overwrite output files" << std::endl;
     std::cerr << "  -o, --output PATH   output file path (default: input with swapped extension)" << std::endl;
     std::cerr << "  -p, --preset NAME   preset for a specific game; see --show-preset" << std::endl;
-    std::cerr << "  -e, --engine TYPE   engine type (AI5*, AI1, ADV)" << std::endl;
+    std::cerr << "  -e, --engine TYPE   engine type (AI5*, AI1, ADV, GM)" << std::endl;
     std::cerr << "  -C, --charset NAME  charset encoding (pc98*, english, europe, korean-..)" << std::endl;
     std::cerr << "  -D, --dictbase HEX  [AI5] dictionary base (80*, D0)" << std::endl;
     std::cerr << "  -E, --extraop       [AI5/ADV] support newer opcodes" << std::endl;
@@ -186,6 +188,8 @@ static void decompile_file(const std::string& path, Config& cfg, bool force,
             }
         } else if (cfg.engine == EngineType::AI1) {
             ast = ai1::load_mes(path, cfg);
+        } else if (cfg.engine == EngineType::GM) {
+            ast = gm::load_mes(path, cfg);
         } else {
             ast = ai5::load_mes(path, cfg);
         }
@@ -338,6 +342,8 @@ static void compile_file(const std::string& path, Config& cfg, bool force,
             compiled = ai1::compile_mes(ast, compile_cfg);
         } else if (compile_cfg.engine == EngineType::AI5) {
             compiled = ai5::compile_mes(ast, compile_cfg);
+        } else if (compile_cfg.engine == EngineType::GM) {
+            compiled = gm::compile_mes(ast, compile_cfg);
         } else {
             throw std::runtime_error("compiler not implemented for this engine");
         }
@@ -474,6 +480,7 @@ int main(int argc, char* argv[]) {
 
                 if (cfg.engine == EngineType::ADV) { engine_name = "ADV"; }
                 else if (cfg.engine == EngineType::AI1) { engine_name = "AI1"; }
+                else if (cfg.engine == EngineType::GM) { engine_name = "GM"; }
                 else { engine_name = "AI5"; }
 
                 print_color("b-cyan", "auto-engine: " + engine_name);

--- a/src/sexp_writer.cpp
+++ b/src/sexp_writer.cpp
@@ -48,7 +48,7 @@ SexpWriter::Style SexpWriter::get_style(const std::string& tag) const {
     }
 
     // structural containers: one statement per line
-    if (tag == "mes" || tag == "seg*" || tag == "loop" ||
+    if (tag == "mes" || tag == "gm-layout" || tag == "seg*" || tag == "loop" ||
         tag == "<>" || tag == "<*>" || tag == "</>" || tag == "<+>" ||
         tag == "/" || tag == "//" || tag == "+" ||
         tag == "repeat") {

--- a/src/sexp_writer.cpp
+++ b/src/sexp_writer.cpp
@@ -43,7 +43,7 @@ SexpWriter::Style SexpWriter::get_style(const std::string& tag) const {
         return Style::Set;
     }
 
-    if (tag == "text" || tag == "str" || tag == "text-raw") {
+    if (tag == "text" || tag == "str" || tag == "text-raw" || tag == "gm-text") {
         return Style::Inline;
     }
 

--- a/tests/test_gm.sh
+++ b/tests/test_gm.sh
@@ -32,6 +32,14 @@ sed 's/(gm-text 2 "BS")/(gm-text 2 "BIGGER")/' \
 printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x40\x2b\x00\x12\x79\x00\x4a\x01\x18\x19\x04\x82\xa4\x00\x4a\x02BIGGER\x00\x00' > "$TMP/expected.mes"
 cmp "$TMP/expected.mes" "$TMP/edited.mes"
 
+sed 's/(gm-text 2 "BS")/(gm-text 2 "B\\nS")/' \
+    "$TMP/output.rkt" > "$TMP/newline.rkt"
+"$JUICE" -c -f -o "$TMP/newline.mes" "$TMP/newline.rkt"
+printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x40\x28\x00\x12\x79\x00\x4a\x01\x18\x19\x04\x82\xa4\x00\x4a\x02B\x04S\x00\x00' > "$TMP/expected-newline.mes"
+cmp "$TMP/expected-newline.mes" "$TMP/newline.mes"
+"$JUICE" -d -f --auto-engine -o "$TMP/newline-output.rkt" "$TMP/newline.mes"
+grep -q '(gm-text 2 "B\\nS")' "$TMP/newline-output.rkt"
+
 sed 's/(raw 110/(raw 0 110/' "$TMP/output.rkt" > "$TMP/bad-raw.rkt"
 "$JUICE" -c -f -o "$TMP/bad-raw.mes" "$TMP/bad-raw.rkt" \
     > "$TMP/bad-raw.log" 2>&1 || true

--- a/tests/test_gm.sh
+++ b/tests/test_gm.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+# Copyright (C) 2026 Fuzion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 # Synthetic General Message detection and byte-exact round-trip test.
 
 set -euo pipefail
@@ -7,6 +24,16 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 JUICE="${1:-$ROOT/build/juice}"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/lime-juice-gm.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
+
+# Exercise the structural detector without the stronger SYSTEM.MLL startup
+# signature. Mode-2 newlines must remain valid GM text tokens.
+printf '%b' '\x02\x00\x4a\x02A\x04B\x00\x4a\x02C\x04D\x00\x00' > "$TMP/heuristic.mes"
+"$JUICE" -d -f --auto-engine -o "$TMP/heuristic.rkt" "$TMP/heuristic.mes"
+grep -q "(engine 'GM)" "$TMP/heuristic.rkt"
+grep -q '(gm-text 2 "A\\nB")' "$TMP/heuristic.rkt"
+grep -q '(gm-text 2 "C\\nD")' "$TMP/heuristic.rkt"
+"$JUICE" -c -f -o "$TMP/heuristic-output.mes" "$TMP/heuristic.rkt"
+cmp "$TMP/heuristic.mes" "$TMP/heuristic-output.mes"
 
 # Header: two dictionary entries (あ, い). Code contains the observed GM
 # SYSTEM.MLL loader signature, a call with a local continuation at 0x27 and an
@@ -22,6 +49,18 @@ grep -q '(gm-text 2 "BS")' "$TMP/output.rkt"
 
 "$JUICE" -c -f -o "$TMP/output.mes" "$TMP/output.rkt"
 cmp "$TMP/input.mes" "$TMP/output.mes"
+
+# Grow mode-1 text through both dictionary and raw Shift-JIS paths. The local
+# continuation moves by one byte while the external MLL target is unchanged.
+sed 's/(gm-text 1 "あい\\nう")/(gm-text 1 "あい\\nうあ")/' \
+    "$TMP/output.rkt" > "$TMP/mode1-edited.rkt"
+"$JUICE" -c -f -o "$TMP/mode1-edited.mes" "$TMP/mode1-edited.rkt"
+printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x40\x28\x00\x12\x79\x00\x4a\x01\x18\x19\x04\x82\xa4\x18\x00\x4a\x02BS\x00\x00' > "$TMP/expected-mode1.mes"
+cmp "$TMP/expected-mode1.mes" "$TMP/mode1-edited.mes"
+
+# The game preset selects GM without relying on auto-detection.
+"$JUICE" -d -f -p fermion -o "$TMP/preset.rkt" "$TMP/input.mes"
+grep -q "(engine 'GM)" "$TMP/preset.rkt"
 
 sed 's/(gm-text 2 "BS")/(gm-text 2 "BIGGER")/' \
     "$TMP/output.rkt" > "$TMP/edited.rkt"
@@ -50,5 +89,26 @@ if [ -e "$TMP/bad-raw.mes" ]; then
 fi
 
 grep -q 'raw nodes with layout metadata cannot change length' "$TMP/bad-raw.log"
+
+# Hand-written GM sources have no layout metadata, but they still cannot exceed
+# the engine's 16-bit file-address space.
+awk 'BEGIN {
+    print "(mes"
+    print " (meta (engine '\''GM) (charset \"pc98\"))"
+    print " (dict)"
+    printf " (raw"
+    for (i = 0; i < 65535; i++) printf " 0"
+    print "))"
+}' > "$TMP/oversize.rkt"
+
+"$JUICE" -c -f -o "$TMP/oversize.mes" "$TMP/oversize.rkt" \
+    > "$TMP/oversize.log" 2>&1 || true
+
+if [ -e "$TMP/oversize.mes" ]; then
+    echo "GM compiler left an oversized output file behind" >&2
+    exit 1
+fi
+
+grep -q 'compiled file exceeds the 16-bit address space' "$TMP/oversize.log"
 
 echo "GM synthetic round-trip and relocation: passed"

--- a/tests/test_gm.sh
+++ b/tests/test_gm.sh
@@ -9,15 +9,38 @@ TMP="$(mktemp -d "${TMPDIR:-/tmp}/lime-juice-gm.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 # Header: two dictionary entries (あ, い). Code contains the observed GM
-# SYSTEM.MLL loader signature, mode-1 dictionary/raw text, and mode-2 ASCII.
-printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x31\x00\x4a\x01\x18\x19\x04\x82\xa4\x00\x50\x00\x4a\x02BS\x00\x00' > "$TMP/input.mes"
+# SYSTEM.MLL loader signature, a call with a local continuation at 0x27 and an
+# external MLL target at 0x7912, mode-1 dictionary/raw text, and mode-2 ASCII.
+printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x40\x27\x00\x12\x79\x00\x4a\x01\x18\x19\x04\x82\xa4\x00\x4a\x02BS\x00\x00' > "$TMP/input.mes"
 
 "$JUICE" -d -f --auto-engine -o "$TMP/output.rkt" "$TMP/input.mes"
 grep -q "(engine 'GM)" "$TMP/output.rkt"
+grep -q '(gm-layout' "$TMP/output.rkt"
+grep -q '(reloc 21 39)' "$TMP/output.rkt"
 grep -q '(gm-text 1 "あい\\nう")' "$TMP/output.rkt"
 grep -q '(gm-text 2 "BS")' "$TMP/output.rkt"
 
 "$JUICE" -c -f -o "$TMP/output.mes" "$TMP/output.rkt"
 cmp "$TMP/input.mes" "$TMP/output.mes"
 
-echo "GM synthetic round-trip: passed"
+sed 's/(gm-text 2 "BS")/(gm-text 2 "BIGGER")/' \
+    "$TMP/output.rkt" > "$TMP/edited.rkt"
+"$JUICE" -c -f -o "$TMP/edited.mes" "$TMP/edited.rkt"
+
+# Growing the second text record by four bytes moves the continuation from
+# 0x27 to 0x2b. The external MLL call target remains exactly 0x7912.
+printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x40\x2b\x00\x12\x79\x00\x4a\x01\x18\x19\x04\x82\xa4\x00\x4a\x02BIGGER\x00\x00' > "$TMP/expected.mes"
+cmp "$TMP/expected.mes" "$TMP/edited.mes"
+
+sed 's/(raw 110/(raw 0 110/' "$TMP/output.rkt" > "$TMP/bad-raw.rkt"
+"$JUICE" -c -f -o "$TMP/bad-raw.mes" "$TMP/bad-raw.rkt" \
+    > "$TMP/bad-raw.log" 2>&1 || true
+
+if [ -e "$TMP/bad-raw.mes" ]; then
+    echo "GM compiler accepted a length-changing raw edit" >&2
+    exit 1
+fi
+
+grep -q 'raw nodes with layout metadata cannot change length' "$TMP/bad-raw.log"
+
+echo "GM synthetic round-trip and relocation: passed"

--- a/tests/test_gm.sh
+++ b/tests/test_gm.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Synthetic General Message detection and byte-exact round-trip test.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+JUICE="${1:-$ROOT/build/juice}"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/lime-juice-gm.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# Header: two dictionary entries (あ, い). Code contains the observed GM
+# SYSTEM.MLL loader signature, mode-1 dictionary/raw text, and mode-2 ASCII.
+printf '%b' '\x06\x00\x82\xa0\x82\xa2\x6e\x11system.mll\x00\x00\x31\x00\x4a\x01\x18\x19\x04\x82\xa4\x00\x50\x00\x4a\x02BS\x00\x00' > "$TMP/input.mes"
+
+"$JUICE" -d -f --auto-engine -o "$TMP/output.rkt" "$TMP/input.mes"
+grep -q "(engine 'GM)" "$TMP/output.rkt"
+grep -q '(gm-text 1 "あい\\nう")' "$TMP/output.rkt"
+grep -q '(gm-text 2 "BS")' "$TMP/output.rkt"
+
+"$JUICE" -c -f -o "$TMP/output.mes" "$TMP/output.rkt"
+cmp "$TMP/input.mes" "$TMP/output.mes"
+
+echo "GM synthetic round-trip: passed"

--- a/tests/test_gm_corpus.sh
+++ b/tests/test_gm_corpus.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# lime-juice: C++ port of Tomyun's "Juice" de/recompiler for PC-98 games
+# Copyright (C) 2026 Fuzion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Usage: tests/test_gm_corpus.sh CORPUS [JUICE]
+#
+# CORPUS may be one MES file or a directory. The test checks GM auto-detection,
+# byte-exact no-op round trips, and changed-length relocation by appending one
+# encodable character to every mode-1 text record. No corpus data is copied into
+# the repository.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 CORPUS [JUICE]" >&2
+    exit 2
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CORPUS="$1"
+JUICE="${2:-$ROOT/build/juice}"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/lime-juice-gm-corpus.XXXXXX")"
+CURRENT=""
+trap 'rm -rf "$TMP"' EXIT
+trap 'echo "GM corpus failure: $CURRENT" >&2' ERR
+
+if [ ! -x "$JUICE" ]; then
+    echo "juice binary is not executable: $JUICE" >&2
+    exit 2
+fi
+
+mes_files() {
+    if [ -f "$CORPUS" ]; then
+        printf '%s\0' "$CORPUS"
+    elif [ -d "$CORPUS" ]; then
+        find "$CORPUS" -type f -iname '*.mes' -print0
+    else
+        echo "corpus path does not exist: $CORPUS" >&2
+        return 2
+    fi
+}
+
+files=0
+mode1_files=0
+mode1_records=0
+
+while IFS= read -r -d '' mes; do
+    CURRENT="$mes"
+    files=$((files + 1))
+
+    "$JUICE" -d -f --auto-engine -o "$TMP/original.rkt" "$mes" >/dev/null
+    grep -q "(engine 'GM)" "$TMP/original.rkt"
+
+    "$JUICE" -c -f -o "$TMP/roundtrip.mes" "$TMP/original.rkt" >/dev/null
+    cmp "$mes" "$TMP/roundtrip.mes"
+
+    record_count=$(grep -c '^[[:space:]]*(gm-text 1 ' "$TMP/original.rkt" || true)
+    if [ "$record_count" -eq 0 ]; then
+        continue
+    fi
+
+    mode1_files=$((mode1_files + 1))
+    mode1_records=$((mode1_records + record_count))
+
+    sed -E 's/^([[:space:]]*\(gm-text 1 ".*)"\)$/\1あ"\)/' \
+        "$TMP/original.rkt" > "$TMP/grown.rkt"
+
+    grown_count=$(grep -c '^[[:space:]]*(gm-text 1 ' "$TMP/grown.rkt" || true)
+    if [ "$grown_count" -ne "$record_count" ] || cmp -s "$TMP/original.rkt" "$TMP/grown.rkt"; then
+        echo "failed to grow every mode-1 record" >&2
+        exit 1
+    fi
+
+    "$JUICE" -c -f -o "$TMP/grown.mes" "$TMP/grown.rkt" >/dev/null
+    if [ "$(wc -c < "$TMP/grown.mes")" -le "$(wc -c < "$mes")" ]; then
+        echo "changed-length compile did not grow the MES file" >&2
+        exit 1
+    fi
+
+    # Decompilation runs the complete structural walker and rejects stale local
+    # targets, so this validates every relocated output instruction boundary.
+    "$JUICE" -d -f -e GM -o "$TMP/grown-output.rkt" "$TMP/grown.mes" >/dev/null
+    grep -q "(engine 'GM)" "$TMP/grown-output.rkt"
+done < <(mes_files)
+
+if [ "$files" -eq 0 ]; then
+    echo "no MES files found in corpus: $CORPUS" >&2
+    exit 1
+fi
+
+printf 'GM corpus: %d files round-tripped; %d mode-1 records grown across %d files\n' \
+    "$files" "$mode1_records" "$mode1_files"

--- a/tests/test_roundtrip.sh
+++ b/tests/test_roundtrip.sh
@@ -57,6 +57,7 @@ while IFS= read -r -d '' rkt; do
     ENGINE="ADV"
     if grep -q "engine 'AI5" "$rkt"; then ENGINE="AI5"; fi
     if grep -q "engine 'AI1" "$rkt"; then ENGINE="AI1"; fi
+    if grep -q "engine 'GM" "$rkt"; then ENGINE="GM"; fi
 
     EXTRA=""
     if grep -q "extraop #t" "$rkt"; then EXTRA="-E"; fi


### PR DESCRIPTION
## Context

This work comes from a preservation and translation project for the PC-98 game
*Fermion: Mirai kara no Houmonsha*. Fermion identifies its interpreter as
`General Message system-1 Rev.95:06:30`.

Its MES container resembles AI5—a little-endian code offset followed by a
two-byte Shift-JIS dictionary—but the bytecode is a different 80-opcode
instruction set. Treating it as AI5 was enough to establish that the format was
incompatible, but not enough to round-trip scripts or safely change text length.

This PR adds a deliberately scoped `GM` engine so Fermion scripts can be
translated without claiming semantic knowledge that has not been recovered yet.

## What changed

- Add `GM` as a CLI/config engine and add a `fermion` game preset.
- Auto-detect GM inside the AI5-style header branch using either:
  - the observed startup form `6e 11 "system.mll" 00 00`; or
  - at least two structurally valid, self-delimiting `0x4a` text records.
- Read the dictionary/header and structurally walk the complete instruction
  stream.
- Emit editable `(gm-text MODE "...")` nodes for proven `0x4a` records:
  - mode 1 supports both dictionary token ranges, raw two-byte Shift-JIS, and
    `0x04` newlines;
  - mode 2 supports printable single-byte text and the same newline control.
- Preserve every other instruction byte-for-byte in `(raw ...)` nodes.
- Emit `gm-layout` metadata containing one original source span per emitted code
  node plus each proven local 16-bit relocation field.
- Recompile changed-length text and remap local control targets while preserving
  external MLL call values.
- Reject resized raw nodes, malformed layout maps, unresolved relocation
  positions, and output beyond the 16-bit MES address space.
- Document the format, current support boundary, and future extension path.
- Add synthetic and optional real-corpus regression tests.

## Why `gm-layout` exists

Only text is represented semantically in this first version. Exposing guessed
names and operands for all surrounding commands would make the source prettier,
but it would also make changed-length compilation depend on unproven semantics.

The walker instead recovers deterministic instruction boundaries and native
address fields. The decompiler records the original span of every following
`raw` or `gm-text` node. On compilation, those spans are mapped to the new output
positions and local fields are backpatched after text encoding.

A target is treated as local only when it is inside the current MES code and
lands on a decoded instruction boundary. Call targets outside the file remain
raw and are not rewritten. Raw nodes must keep their original length because
there is not yet a semantic representation from which to rebuild them safely.

This is intended to be incremental: later opcode parsers can replace individual
raw regions with semantic nodes while retaining the same relocation model.

## Detection regression matrix

The GM heuristic was run with `--auto-engine` against 1,204 scenario files from
10 shipped non-Fermion games. ADV detection runs before the AI5/GM branch, and
the expanded corpus confirms that GM does not shadow any of the existing engine
families.

| Family | Files | Titles | GM false positives | Decompile failures |
|---|---:|---:|---:|---:|
| AI1 | 251 | 4 | 0 | 0 |
| AI5 | 468 | 3 | 0 | 0 |
| ADV | 485 | 3 | 0 | 0 |
| **Total** | **1,204** | **10** | **0** | **0** |

The titles were Angel Hearts, De-Ja, Dragon Knight II, Dragoon Armor for Adult,
Doukyuusei, Dragon Knight 4, Foxy 2, Dead of the Brain, Dead of the Brain 2, and
Koroshi no Dress 3.

No game data is included in this repository.

## Fermion validation

The original Fermion corpus contains 96 on-disk MES copies representing 77
unique SHA-256 hashes.

- All 96 auto-detect as GM and perform a byte-exact no-op
  decompile/recompile round trip.
- The corpus contains 130,119 decoded instructions when duplicate on-disk copies
  are included.
- All 17,044 in-file targets land on decoded instruction boundaries.
- The remaining 5,971 address operands are external MLL call targets.
- A changed-length stress test appended an encodable character to all 26,293
  mode-1 text records across 93 files; every rebuilt file passed the structural
  walker.
- A translated image has also been exercised in the PC-98 runtime with resized
  menu and dialogue text, including mode-2 newlines.

`tests/test_gm_corpus.sh` makes the no-op and changed-length corpus checks
reproducible for anyone who supplies their own MES files. It copies nothing into
the source tree.

## Automated and build checks

```console
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --target juice
tests/test_gm.sh build/juice
tests/test_gm_corpus.sh /path/to/fermion/mes build/juice
```

The synthetic test covers:

- heuristic detection without the stronger `SYSTEM.MLL` marker;
- mode-1 and mode-2 text, including newlines;
- byte-exact round-trip;
- changed-length relocation;
- preservation of an external MLL target;
- rejection of resized raw nodes; and
- rejection of output beyond the 16-bit address space.

Additional checks performed for this branch:

- clean macOS AppleClang Release build;
- AppleClang ASan/UBSan synthetic and 96-file corpus runs; and
- `x86_64-w64-mingw32-g++` cross-build of `juice.exe` using the vendored Windows
  iconv fallback.

## Scope and known limits

- The implementation is derived from and validated against Fermion's General
  Message system-1 Rev.95:06:30 dialect. A second GM title has not yet been
  validated.
- Fermion exercises 54 of the 80 dispatched opcodes plus the `0x00` interpreter
  terminator. The other 26 dispatcher slots are not present in the shipped
  Fermion scripts.
- Only `0x4a` text has a semantic AST node today. Scenario/module loading and the
  other command layouts are structurally decoded but remain raw.
- Resizing raw nodes is intentionally unsupported.
- Native MSVC and Linux builds have not been run; the MinGW Windows cross-build
  is green.

The two areas where maintainer review would be especially useful are the
`gm-layout` source-map format and the conservativeness of `looks_like_gm`.
